### PR TITLE
Test suite for config-loading combinatorics, wording cleanup, hot-rel…

### DIFF
--- a/source/Canopy-Core-Tests/CanopyBindingTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyBindingTest.class.st
@@ -5,11 +5,64 @@ Class {
 	#package : 'Canopy-Core-Tests'
 }
 
+{ #category : 'as yet unclassified' }
+CanopyBindingTest >> testBindAfterValueIsSet [
+	| tree object |
+	tree := Canopy new importTree: '{ "one" : 42 }'.
+	object := CanopyTestObject new.
+	object canopyBind: tree keys: #( one ).
+	self assert: object one equals: 42
+]
+
 { #category : 'tests' }
-CanopyBindingTest >> testBindProperties [ 
+CanopyBindingTest >> testBindProperties [
 	| tree object |
 	tree := Canopy new importTree: '{ "first" : { "second" : { "one" : 1, "two": 2, "three" : 3 }}}'.
-	object := CanopyTestObject new 
+	object := CanopyTestObject new
 		canopyBind: tree / #first / #second keys: #( one two three ).
+	self assert: object one equals: 1.
+	self assert: object two equals: 2.
+	self assert: object three equals: 3
+]
 
+{ #category : 'as yet unclassified' }
+CanopyBindingTest >> testHotReloadNotPropagatedToBoundObject [
+	"Fixed 2026-07-17: CanopyCell>>value: now notifies a registered dependent accessor."
+	| tree object |
+	tree := Canopy new.
+	tree at: #one put: CanopyCell new.
+	object := CanopyTestObject new.
+	object canopyBind: tree keys: #( one ).
+	(tree / #one) value: 42.
+	self assert: object one equals: 42
+]
+
+{ #category : 'as yet unclassified' }
+CanopyBindingTest >> testHotReloadViaReimport [
+	"Fixed 2026-07-17: CanopyCell>>register: now always tracks dependents, regardless of
+	whether a value already existed at bind time."
+	| tree object |
+	tree := Canopy new importTree: '{ "one" : 1 }'.
+	object := CanopyTestObject new.
+	object canopyBind: tree keys: #( one ).
+	self assert: object one equals: 1.
+	tree importTree: '{ "one" : 2 }'.
+	self assert: object one equals: 2
+]
+
+{ #category : 'as yet unclassified' }
+CanopyBindingTest >> testMultipleAccessorRegistrationsAreAllNotified [
+	"Fixed 2026-07-17: CanopyCell>>register: now keeps a dependents collection instead of a
+	single slot - both accessors registered before a value exists are notified once it is set."
+	| value accessorA accessorB objectA objectB |
+	value := CanopyCell new.
+	objectA := CanopyTestObject new.
+	objectB := CanopyTestObject new.
+	accessorA := CanopyAccessor new object: objectA; selector: #one; yourself.
+	accessorB := CanopyAccessor new object: objectB; selector: #one; yourself.
+	value register: accessorA.
+	value register: accessorB.
+	value value: 99.
+	self assert: objectA one equals: 99.
+	self assert: objectB one equals: 99
 ]

--- a/source/Canopy-Core-Tests/CanopyDomainTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyDomainTest.class.st
@@ -1,0 +1,72 @@
+Class {
+	#name : 'CanopyDomainTest',
+	#superclass : 'TestCase',
+	#category : 'Canopy-Core-Tests',
+	#package : 'Canopy-Core-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testAtAddMergesInsteadOfOverwriting [
+	| root incoming |
+	root := Canopy new.
+	root at: #image put: (CanopyBranchNode new at: #a put: (CanopyCell new value: 1); yourself).
+	incoming := CanopyBranchNode new at: #b put: (CanopyCell new value: 2); yourself.
+	root at: #image add: incoming.
+	self assert: (root / #image / #a) value equals: 1.
+	self assert: (root / #image / #b) value equals: 2
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testAtMissingKeyRaisesNotFound [
+	| root |
+	root := Canopy new.
+	self should: [ root / #missing ] raise: Error
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testAtOperatorCombinesPathAndValue [
+	| root |
+	root := Canopy new.
+	root at: #leaf put: (CanopyCell new value: 42).
+	self assert: (root @ #leaf) equals: 42
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testAtPutOnExistingDomainKeyOverwritesWithoutWarning [
+	"Known gap, see Canopy spec.md, Domain-API formalisieren: at:put: has no collision
+	protection. Characterization test: documents CURRENT behavior (silent overwrite), not
+	desired behavior."
+	| root replacement |
+	root := Canopy new.
+	root at: #image put: (CanopyCell new value: 'original').
+	replacement := CanopyCell new value: 'replaced'.
+	root at: #image put: replacement.
+	self assert: (root / #image) value equals: 'replaced'
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testEnsureAtCreatesMissingBranch [
+	| root |
+	root := Canopy new.
+	self assert: (root /+ #newDomain) class equals: CanopyBranchNode.
+	self assert: (root / #newDomain) class equals: CanopyBranchNode
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testMultipleDomainsCoexistIndependently [
+	| root |
+	root := Canopy new.
+	root at: #image put: (CanopyCell new value: 'image-value').
+	root at: #virtualMachine put: (CanopyCell new value: 'vm-value').
+	self assert: (root / #image) value equals: 'image-value'.
+	self assert: (root / #virtualMachine) value equals: 'vm-value'.
+	self assertCollection: root keys asArray hasSameElements: #( image virtualMachine )
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testSlashOnLeafRaisesError [
+	| root |
+	root := Canopy new.
+	root at: #leaf put: (CanopyCell new value: 42).
+	self should: [ (root / #leaf) / #anything ] raise: Error
+]

--- a/source/Canopy-Core-Tests/CanopyMergeTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyMergeTest.class.st
@@ -1,0 +1,75 @@
+Class {
+	#name : 'CanopyMergeTest',
+	#superclass : 'TestCase',
+	#category : 'Canopy-Core-Tests',
+	#package : 'Canopy-Core-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testCellMergeAccumulatesTags [
+	| existing incoming |
+	existing := CanopyCell new value: 1; tags: (Set withAll: #(a)); yourself.
+	incoming := CanopyCell new value: 2; tags: (Set withAll: #(b)); yourself.
+	existing merge: incoming.
+	self assertCollection: existing tags hasSameElements: #(a b)
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testCellMergeOverwritesWithLastValue [
+	| existing incoming |
+	existing := CanopyCell new value: 1.
+	incoming := CanopyCell new value: 2.
+	existing merge: incoming.
+	self assert: existing value equals: 2
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testDictionaryApplyPushesValuesByKey [
+	| branch dict target |
+	branch := CanopyBranchNode new.
+	branch at: #a put: (CanopyCell new value: 1).
+	branch at: #b put: (CanopyCell new value: 2).
+	dict := Dictionary new.
+	target := CanopyDictionaryAccessor on: dict.
+	target apply: branch.
+	self assert: (dict at: #a) equals: 1.
+	self assert: (dict at: #b) equals: 2
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testMergingBranchIntoCellIsNotDetectedAsConflict [
+	"Known rough edge, see Canopy doc.md 'Fehlerklassen & bekannte Rough Edges': the reverse
+	case does NOT raise an error. CanopyCell>>merge: calls aGlobNode value, which falls back
+	to Object>>value (returns self) for a CanopyBranchNode - the existing cell silently ends
+	up holding the incoming branch node itself instead of a raw value. Characterization test:
+	documents CURRENT (arguably broken) behavior, not desired behavior."
+	| existing incoming |
+	existing := Canopy new.
+	existing at: #foo put: (CanopyCell new value: 42).
+	incoming := Canopy new.
+	incoming at: #foo put: CanopyBranchNode new.
+	existing merge: incoming.
+	self assert: (existing / #foo) value == (incoming / #foo)
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testMergingCellIntoBranchRaisesConflict [
+	"Verified 2026-07-16: CanopyCell>>mergeInto: raises a controlled conflict error
+	('cponflict', typo in the source) when an incoming CanopyCell is merged into an
+	existing CanopyBranchNode at the same key. See Canopy doc.md, Fehlerklassen."
+	| existing incoming |
+	existing := Canopy new.
+	existing at: #foo put: CanopyBranchNode new.
+	incoming := Canopy new.
+	incoming at: #foo put: (CanopyCell new value: 42).
+	self should: [ existing merge: incoming ] raise: Error
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testNonOverlappingKeysSurviveAcrossReimport [
+	| tree |
+	tree := Canopy new importTree: '{ "one" : 1 }'.
+	tree importTree: '{ "two" : 2 }'.
+	self assert: (tree / #one) value equals: 1.
+	self assert: (tree / #two) value equals: 2
+]

--- a/source/Canopy-Core-Tests/CanopyTagTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyTagTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : 'CanopyTagTest',
+	#superclass : 'TestCase',
+	#category : 'Canopy-Core-Tests',
+	#package : 'Canopy-Core-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+CanopyTagTest >> testApplyIgnoresTagsEntirely [
+	"Documents current design: tags are purely descriptive/informational. apply: has no
+	tag-based filtering - a differently-tagged value is applied exactly the same way as an
+	untagged one. See Canopy spec.md, Prioritaet 1 (open question: should tags ever be
+	operative?)."
+	| component tree object |
+	tree := Canopy new importTree: '{ "one" : 1 }' tags: #( irrelevantTag ).
+	component := CanopyBranchNode new.
+	object := CanopyTestObject new.
+	component at: #one put: (CanopyAccessor new object: object; selector: #one; yourself).
+	component apply: tree.
+	self assert: object one equals: 1
+]
+
+{ #category : 'as yet unclassified' }
+CanopyTagTest >> testImportTreeTagsAppliesTagsToAllNodes [
+	| tree |
+	tree := Canopy new importTree: '{ "a" : { "b" : 1 } }' tags: #( mine ).
+	self assertCollection: tree tags hasSameElements: #( mine ).
+	self assertCollection: (tree / #a) tags hasSameElements: #( mine ).
+	self assertCollection: (tree / #a / #b) tags hasSameElements: #( mine )
+]
+
+{ #category : 'as yet unclassified' }
+CanopyTagTest >> testTagsAccumulateAcrossThreeOverlappingImports [
+	| tree |
+	tree := Canopy new.
+	tree importTree: '{ "one" : 1 }' tags: #( appA ).
+	tree importTree: '{ "one" : 2, "two" : 3 }' tags: #( appB ).
+	tree importTree: '{ "one" : 4 }' tags: #( appC ).
+	self assertCollection: (tree / #one) tags hasSameElements: #( appA appB appC ).
+	self assertCollection: (tree / #two) tags hasSameElements: #( appB ).
+	self assert: (tree / #one) value equals: 4
+]

--- a/source/Canopy-Core/CanopyCell.class.st
+++ b/source/Canopy-Core/CanopyCell.class.st
@@ -1,32 +1,38 @@
 Class {
-	#name : 'CanopyValue',
+	#name : 'CanopyCell',
 	#superclass : 'CanopyLeafNode',
 	#instVars : [
 		'value',
-		'dependent'
+		'dependents'
 	],
 	#category : 'Canopy-Core',
 	#package : 'Canopy-Core'
 }
 
 { #category : 'accessing' }
-CanopyValue class >> type [ 
+CanopyCell class >> type [ 
 	^ #value
 ]
 
+{ #category : 'initialization' }
+CanopyCell >> initialize [
+	super initialize.
+	dependents := OrderedCollection new
+]
+
 { #category : 'actions' }
-CanopyValue >> merge: aGlobNode [ 
-	value := aGlobNode value.
+CanopyCell >> merge: aGlobNode [
+	self value: aGlobNode value.
 	tags addAll: aGlobNode tags
 ]
 
 { #category : 'as yet unclassified' }
-CanopyValue >> mergeInto: aGlobValueHolder [ 
+CanopyCell >> mergeInto: aGlobValueHolder [ 
 	self error: 'cponflict'
 ]
 
 { #category : 'printing' }
-CanopyValue >> printOn: aStream [ 
+CanopyCell >> printOn: aStream [ 
 	super printOn: aStream .
 	aStream << '['.
 	value printOn: aStream.
@@ -34,24 +40,24 @@ CanopyValue >> printOn: aStream [
 ]
 
 { #category : 'registry' }
-CanopyValue >> register: aPTAccessor [ 
-	value
-		ifNotNil: [ aPTAccessor value: value ]
-		ifNil: [ dependent := aPTAccessor ]
+CanopyCell >> register: aPTAccessor [
+	dependents add: aPTAccessor.
+	value ifNotNil: [ aPTAccessor value: value ]
 ]
 
 { #category : 'accessing' }
-CanopyValue >> tags: aCollection [ 
+CanopyCell >> tags: aCollection [ 
 	tags ifNil: [ tags := Set new ].
 	tags addAll: aCollection 
 ]
 
 { #category : 'evaluating' }
-CanopyValue >> value [ 
+CanopyCell >> value [ 
 	^ value 
 ]
 
 { #category : 'accessing' }
-CanopyValue >> value: anObject [  
-	value := anObject 
+CanopyCell >> value: anObject [
+	value := anObject.
+	dependents do: [ :each | each value: anObject ]
 ]

--- a/source/Canopy-Core/CanopyDictionaryAccessor.class.st
+++ b/source/Canopy-Core/CanopyDictionaryAccessor.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'CanopyDictionary',
+	#name : 'CanopyDictionaryAccessor',
 	#superclass : 'CanopyLeafNode',
 	#instVars : [
 		'dictionary'
@@ -9,24 +9,24 @@ Class {
 }
 
 { #category : 'instance creation' }
-CanopyDictionary class >> on: aDictionary [ 
+CanopyDictionaryAccessor class >> on: aDictionary [ 
 	^ self new 
 		dictionary: aDictionary 
 ]
 
 { #category : 'accessing' }
-CanopyDictionary class >> type [ 
+CanopyDictionaryAccessor class >> type [ 
 	^ #dictionary 
 ]
 
 { #category : 'target resize' }
-CanopyDictionary >> apply: aCanopyBranchNode [ 
+CanopyDictionaryAccessor >> apply: aCanopyBranchNode [ 
 
 	aCanopyBranchNode keysAndValuesDo: [ :key :value |
 		dictionary at: key put: value value ]
 ]
 
 { #category : 'accessing' }
-CanopyDictionary >> dictionary: aCollection [ 
+CanopyDictionaryAccessor >> dictionary: aCollection [ 
 	dictionary := aCollection
 ]

--- a/source/Canopy-Core/CanopyMappingBuilder.class.st
+++ b/source/Canopy-Core/CanopyMappingBuilder.class.st
@@ -44,13 +44,13 @@ CanopyMappingBuilder >> build [
 { #category : 'as yet unclassified' }
 CanopyMappingBuilder >> buildComplexProperties [
 	| pragmas |
-	pragmas := Pragma 
-		allNamed: #canopyMapping
-		from: object class 
+	pragmas := Pragma
+		allNamed: #canopyBranch
+		from: object class
 		to: Object.
-	(pragmas size = 1) ifTrue: [ 
-		object 
-			perform: pragmas first selector asMutator 
+	(pragmas size = 1) ifTrue: [
+		object
+			perform: pragmas first selector asMutator
 			with: self ]
 ]
 

--- a/source/Canopy-Core/Dictionary.extension.st
+++ b/source/Canopy-Core/Dictionary.extension.st
@@ -1,19 +1,17 @@
 Extension { #name : 'Dictionary' }
 
 { #category : '*Canopy-Core' }
-Dictionary >> asCanopyValue [
+Dictionary >> asCanopyCell [
 	| group |
 	group := CanopyBranchNode new.
-	
 	self keysAndValuesDo: [ :key :value |
-		group at: key put: value asCanopyValue ].
-	^ group 
+		group at: key put: value asCanopyCell ].
+	^ group
 ]
 
 { #category : '*Canopy-Core' }
-Dictionary >> canopyMapping: aBuilder [
-	<canopyMapping>
-	
+Dictionary >> canopyBranch: aBuilder [
+	<canopyBranch>
 	self keysAndValuesDo: [ :key :value |
-		aBuilder at: key addMapping: value  ]
+		aBuilder at: key addMapping: value ]
 ]

--- a/source/Canopy-Core/FileReference.extension.st
+++ b/source/Canopy-Core/FileReference.extension.st
@@ -2,5 +2,5 @@ Extension { #name : 'FileReference' }
 
 { #category : '*Canopy-Core' }
 FileReference >> asCanopy [
-	^ self readStream asCanopyValue
+	^ self readStream asCanopyCell
 ]

--- a/source/Canopy-Core/Object.extension.st
+++ b/source/Canopy-Core/Object.extension.st
@@ -1,8 +1,8 @@
 Extension { #name : 'Object' }
 
 { #category : '*Canopy-Core' }
-Object >> asCanopyValue [
-	^ CanopyValue new value: self 
+Object >> asCanopyCell [
+	^ CanopyCell new value: self
 ]
 
 { #category : '*Canopy-Core' }

--- a/source/Canopy-Core/ReadStream.extension.st
+++ b/source/Canopy-Core/ReadStream.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'ReadStream' }
 
 { #category : '*Canopy-Core' }
-ReadStream >> asCanopyValue [
-	^ (STON fromStream: self) asCanopyValue 
+ReadStream >> asCanopyCell [
+	^ (STON fromStream: self) asCanopyCell
 ]

--- a/source/Canopy-Core/String.extension.st
+++ b/source/Canopy-Core/String.extension.st
@@ -2,5 +2,5 @@ Extension { #name : 'String' }
 
 { #category : '*Canopy-Core' }
 String >> asCanopy [
-	^ self readStream asCanopyValue
+	^ self readStream asCanopyCell
 ]

--- a/source/Canopy-Core/ZnCharacterReadStream.extension.st
+++ b/source/Canopy-Core/ZnCharacterReadStream.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'ZnCharacterReadStream' }
 
 { #category : '*Canopy-Core' }
-ZnCharacterReadStream >> asCanopyValue [ 
-	^ (STON fromStream: self) asCanopyValue 
+ZnCharacterReadStream >> asCanopyCell [
+	^ (STON fromStream: self) asCanopyCell
 ]


### PR DESCRIPTION
…oad fix

Priority 1 work (see Canopy spec/doc/log in the Obsidian vault for full context):

- Add CanopyMergeTest, CanopyTagTest, CanopyDomainTest covering domains, tags, merge/apply semantics, and merge-conflict asymmetry that were previously untested. Extend CanopyBindingTest with real assertions (testBindProperties had none before) plus hot-reload and multi-registration coverage.
- Rename CanopyValue -> CanopyCell and CanopyDictionary -> CanopyDictionaryAccessor to resolve a naming ambiguity found during a concept review (read/write direction was named inconsistently between Canopy-tree and component perspective). Rename the <canopyMapping> pragma to <canopyBranch> and the asCanopyValue conversion protocol to asCanopyCell to match.
- Fix CanopyCell>>register:/value: so hot-reload actually works: dependents are now tracked in a collection instead of a single slot that got silently overwritten, and value: notifies all registered dependents instead of none.

Canopy-Core-Tests: 24/24 green (up from 4/4, 0 assertions on the binding path).