### PR TITLE
Add CanopyDictionaryAccessor>>value

### DIFF
--- a/source/Canopy-Core-Tests/CanopyMergeTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyMergeTest.class.st
@@ -24,6 +24,18 @@ CanopyMergeTest >> testCellMergeOverwritesWithLastValue [
 ]
 
 { #category : 'as yet unclassified' }
+CanopyMergeTest >> testDictionaryAccessorValueReturnsWrappedDictionary [
+	"Previously missing (see Canopy roadmap): without it, value/inspectionValue
+	silently fell back to Object>>value (returns self) instead of DNU-ing,
+	which is misleading in the debugger/inspector - not a crash, but wrong."
+	| dict target |
+	dict := Dictionary new.
+	target := CanopyDictionaryAccessor on: dict.
+	self assert: target value == dict.
+	self assert: target inspectionValue == dict
+]
+
+{ #category : 'as yet unclassified' }
 CanopyMergeTest >> testDictionaryApplyPushesValuesByKey [
 	| branch dict target |
 	branch := CanopyBranchNode new.

--- a/source/Canopy-Core/CanopyDictionaryAccessor.class.st
+++ b/source/Canopy-Core/CanopyDictionaryAccessor.class.st
@@ -27,6 +27,11 @@ CanopyDictionaryAccessor >> apply: aCanopyBranchNode [
 ]
 
 { #category : 'accessing' }
-CanopyDictionaryAccessor >> dictionary: aCollection [ 
+CanopyDictionaryAccessor >> dictionary: aCollection [
 	dictionary := aCollection
+]
+
+{ #category : 'evaluating' }
+CanopyDictionaryAccessor >> value [
+	^ dictionary
 ]


### PR DESCRIPTION
Without it, value/inspectionValue silently fell back to Object>>value (returns self) instead of failing - CanopyLeafNode>>inspectionValue assumes value is implemented, so debugger/inspector display was wrong (showing the accessor itself) rather than crashing. Now returns the wrapped dictionary, matching CanopyCell>>value's pattern of exposing the raw wrapped value.