### PR TITLE
Add tests for the declarative canopySetupFrom:/canopySetupFromFile: e…

### DIFF
--- a/source/Canopy-Core-Tests/CanopyBindingTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyBindingTest.class.st
@@ -14,6 +14,30 @@ CanopyBindingTest >> testBindAfterValueIsSet [
 	self assert: object one equals: 42
 ]
 
+{ #category : 'as yet unclassified' }
+CanopyBindingTest >> testCanopySetupFromBindsAndAppliesConfig [
+	"Covers the declarative entry point Object>>canopySetupFrom: - builds the
+	receiver's own component tree via pragma reflection and applies the given
+	config object onto it in one call. Previously untested, see Canopy roadmap."
+	| object |
+	object := CanopyRootTestObject new.
+	object canopySetupFrom: '{ "one" : 42 }'.
+	self assert: object one equals: 42
+]
+
+{ #category : 'as yet unclassified' }
+CanopyBindingTest >> testCanopySetupFromFileBindsAndAppliesConfig [
+	"Covers the declarative entry point Object>>canopySetupFromFile: - same as
+	canopySetupFrom:, but reading the config from an actual file on disk."
+	| object file |
+	file := FileLocator temp / 'canopy-setup-test.json'.
+	file writeStreamDo: [ :stream | stream nextPutAll: '{ "one" : 42 }' ].
+	object := CanopyRootTestObject new.
+	[ object canopySetupFromFile: file fullName ]
+		ensure: [ file ensureDelete ].
+	self assert: object one equals: 42
+]
+
 { #category : 'tests' }
 CanopyBindingTest >> testBindProperties [
 	| tree object |

--- a/source/Canopy-Core-Tests/CanopyRootTestObject.class.st
+++ b/source/Canopy-Core-Tests/CanopyRootTestObject.class.st
@@ -1,6 +1,20 @@
 Class {
 	#name : 'CanopyRootTestObject',
 	#superclass : 'Object',
+	#instVars : [
+		'one'
+	],
 	#category : 'Canopy-Core-Tests',
 	#package : 'Canopy-Core-Tests'
 }
+
+{ #category : 'accessing' }
+CanopyRootTestObject >> one [
+	<canopyValue: #one type: #accessor arguments: #()>
+	^ one
+]
+
+{ #category : 'accessing' }
+CanopyRootTestObject >> one: anObject [
+	one := anObject
+]


### PR DESCRIPTION
…ntry point

This is the entry point suspected to be the actual production-used config loading path (Object>>canopySetupFrom:/canopySetupFromFile:, found during the 2026-07-17 wording review), but it had zero test coverage until now.

CanopyRootTestObject gets a real pragma-tagged accessor (one/one:) so the pragma-reflection path (CanopyMappingBuilder>>buildLocalProperties) is actually exercised, not just canopyBind:keys: with a manually built tree as the other CanopyBindingTest cases do.