### PR TITLE
Add tag-based selective apply: (apply:withTag:)

### DIFF
--- a/source/Canopy-Core-Tests/CanopyMergeTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyMergeTest.class.st
@@ -37,6 +37,20 @@ CanopyMergeTest >> testDictionaryApplyPushesValuesByKey [
 ]
 
 { #category : 'as yet unclassified' }
+CanopyMergeTest >> testDictionaryApplyWithTagOnlyAppliesWhenBranchTagMatches [
+	| branch dict target |
+	branch := CanopyBranchNode new.
+	branch at: #a put: (CanopyCell new value: 1).
+	branch addTag: #config.
+	dict := Dictionary new.
+	target := CanopyDictionaryAccessor on: dict.
+	target apply: branch withTag: #metrics.
+	self deny: (dict includesKey: #a).
+	target apply: branch withTag: #config.
+	self assert: (dict at: #a) equals: 1
+]
+
+{ #category : 'as yet unclassified' }
 CanopyMergeTest >> testMergingBranchIntoCellIsNotDetectedAsConflict [
 	"Known rough edge, see Canopy doc.md 'Fehlerklassen & bekannte Rough Edges': the reverse
 	case does NOT raise an error. CanopyCell>>merge: calls aGlobNode value, which falls back

--- a/source/Canopy-Core-Tests/CanopyTagTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyTagTest.class.st
@@ -21,6 +21,25 @@ CanopyTagTest >> testApplyIgnoresTagsEntirely [
 ]
 
 { #category : 'as yet unclassified' }
+CanopyTagTest >> testApplyWithTagOnlyAppliesMatchingTaggedValues [
+	"apply:withTag: filters at the leaf level - only values tagged with the given tag
+	are pushed into the component tree. Differently-tagged values interleaved in the
+	same branch are left untouched, unlike plain apply: (see testApplyIgnoresTagsEntirely)."
+	| component tree object |
+	tree := Canopy new.
+	tree importTree: '{ "one" : 1 }' tags: #( config ).
+	tree importTree: '{ "two" : 2 }' tags: #( metrics ).
+	component := CanopyBranchNode new.
+	object := CanopyTestObject new.
+	object one: 0; two: 0.
+	component at: #one put: (CanopyAccessor new object: object; selector: #one; yourself).
+	component at: #two put: (CanopyAccessor new object: object; selector: #two; yourself).
+	component apply: tree withTag: #config.
+	self assert: object one equals: 1.
+	self assert: object two equals: 0
+]
+
+{ #category : 'as yet unclassified' }
 CanopyTagTest >> testImportTreeTagsAppliesTagsToAllNodes [
 	| tree |
 	tree := Canopy new importTree: '{ "a" : { "b" : 1 } }' tags: #( mine ).

--- a/source/Canopy-Core/CanopyBranchNode.class.st
+++ b/source/Canopy-Core/CanopyBranchNode.class.st
@@ -48,10 +48,25 @@ CanopyBranchNode >> apply: aGlobBranch [
 		 ]
 ]
 
+{ #category : 'target resize' }
+CanopyBranchNode >> apply: aGlobBranch withTag: aTag [
+	aGlobBranch keysAndValuesDo: [ :key :value |
+		(value isKindOf: CanopyBranchNode)
+			ifTrue: [
+				nodes
+					at: key
+					ifPresent: [ :sn | sn apply: value withTag: aTag ] ]
+			ifFalse: [
+				(value tags includes: aTag) ifTrue: [
+					nodes
+						at: key
+						ifPresent: [ :sn | sn value: value value ] ] ] ]
+]
+
 { #category : 'accessing' }
-CanopyBranchNode >> at: key [ 
-	^ nodes 
-		at: key 
+CanopyBranchNode >> at: key [
+	^ nodes
+		at: key
 		ifAbsent: [ NotFound signal: 'cannot find key ', key asString , ' in ', self printString ]
 ]
 

--- a/source/Canopy-Core/CanopyDictionaryAccessor.class.st
+++ b/source/Canopy-Core/CanopyDictionaryAccessor.class.st
@@ -26,7 +26,13 @@ CanopyDictionaryAccessor >> apply: aCanopyBranchNode [
 		dictionary at: key put: value value ]
 ]
 
+{ #category : 'target resize' }
+CanopyDictionaryAccessor >> apply: aCanopyBranchNode withTag: aTag [
+	(aCanopyBranchNode tags includes: aTag) ifTrue: [
+		self apply: aCanopyBranchNode ]
+]
+
 { #category : 'accessing' }
-CanopyDictionaryAccessor >> dictionary: aCollection [ 
+CanopyDictionaryAccessor >> dictionary: aCollection [
 	dictionary := aCollection
 ]


### PR DESCRIPTION
CanopyBranchNode>>apply: already applies incoming values regardless of tag (see testApplyIgnoresTagsEntirely). This adds a sibling apply:withTag: that filters at the leaf level: a leaf is only pushed into the component tree if its own tags include the given tag. Branches are always recursed into, since tags can interleave within the same branch (e.g. #config and #metrics values side by side).

CanopyDictionaryAccessor>>apply:withTag: mirrors this by checking the incoming branch's own tag before consuming it whole, since it consumes an entire substructure rather than a scalar.