### PR TITLE
Remove unused Canopy>>root ivar

### DIFF
--- a/source/Canopy-Core/Canopy.class.st
+++ b/source/Canopy-Core/Canopy.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : 'Canopy',
 	#superclass : 'CanopyBranchNode',
-	#instVars : [
-		'root'
-	],
 	#classInstVars : [
 		'instance'
 	],


### PR DESCRIPTION
No accessor, no references anywhere in the image - confirmed via reflection (0 own instance methods on Canopy, all instance-side behavior inherited from CanopyBranchNode). Already decided as removable (2026-07-17), tracked in Canopy roadmap.