### PR TITLE
Remove dead CanopyMappingBuilder class>>build:

### DIFF
--- a/source/Canopy-Core/CanopyMappingBuilder.class.st
+++ b/source/Canopy-Core/CanopyMappingBuilder.class.st
@@ -9,11 +9,6 @@ Class {
 	#package : 'Canopy-Core'
 }
 
-{ #category : 'instance creation' }
-CanopyMappingBuilder class >> build: anObject [ 
-	^ self new build: anObject
-]
-
 { #category : 'adding' }
 CanopyMappingBuilder >> addMapping: anObject [
 	self class new 


### PR DESCRIPTION
Calls self new build: anObject, but the instance side only implements build (no argument) - this selector cannot be sent successfully. Confirmed 0 senders in the image. Already decided as removable (2026-07-17), tracked in Canopy roadmap.