### PR TITLE
Add registerDomain:with: with collision protection, domains listing

### DIFF
--- a/source/Canopy-Core-Tests/CanopyBindingTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyBindingTest.class.st
@@ -14,6 +14,17 @@ CanopyBindingTest >> testBindAfterValueIsSet [
 	self assert: object one equals: 42
 ]
 
+{ #category : 'tests' }
+CanopyBindingTest >> testBindProperties [
+	| tree object |
+	tree := Canopy new importTree: '{ "first" : { "second" : { "one" : 1, "two": 2, "three" : 3 }}}'.
+	object := CanopyTestObject new
+		canopyBind: tree / #first / #second keys: #( one two three ).
+	self assert: object one equals: 1.
+	self assert: object two equals: 2.
+	self assert: object three equals: 3
+]
+
 { #category : 'as yet unclassified' }
 CanopyBindingTest >> testCanopySetupFromBindsAndAppliesConfig [
 	"Covers the declarative entry point Object>>canopySetupFrom: - builds the
@@ -36,17 +47,6 @@ CanopyBindingTest >> testCanopySetupFromFileBindsAndAppliesConfig [
 	[ object canopySetupFromFile: file fullName ]
 		ensure: [ file ensureDelete ].
 	self assert: object one equals: 42
-]
-
-{ #category : 'tests' }
-CanopyBindingTest >> testBindProperties [
-	| tree object |
-	tree := Canopy new importTree: '{ "first" : { "second" : { "one" : 1, "two": 2, "three" : 3 }}}'.
-	object := CanopyTestObject new
-		canopyBind: tree / #first / #second keys: #( one two three ).
-	self assert: object one equals: 1.
-	self assert: object two equals: 2.
-	self assert: object three equals: 3
 ]
 
 { #category : 'as yet unclassified' }

--- a/source/Canopy-Core-Tests/CanopyDomainTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyDomainTest.class.st
@@ -33,15 +33,25 @@ CanopyDomainTest >> testAtOperatorCombinesPathAndValue [
 
 { #category : 'as yet unclassified' }
 CanopyDomainTest >> testAtPutOnExistingDomainKeyOverwritesWithoutWarning [
-	"Known gap, see Canopy spec.md, Domain-API formalisieren: at:put: has no collision
-	protection. Characterization test: documents CURRENT behavior (silent overwrite), not
-	desired behavior."
+	"at:put: itself intentionally stays ungated — it is also used internally for tree/merge
+	mechanics that rely on overwrite semantics. Callers that want collision protection for
+	top-level domains should use registerDomain:with: instead (see testRegisterDomainRaisesOnCollisionAndDoesNotOverwrite).
+	This test documents that at:put: itself still silently overwrites."
 	| root replacement |
 	root := Canopy new.
 	root at: #image put: (CanopyCell new value: 'original').
 	replacement := CanopyCell new value: 'replaced'.
 	root at: #image put: replacement.
 	self assert: (root / #image) value equals: 'replaced'
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testDomainsListsAllRegisteredDomains [
+	| root |
+	root := Canopy new.
+	root registerDomain: #image with: (CanopyCell new value: 1).
+	root registerDomain: #virtualMachine with: (CanopyCell new value: 2).
+	self assertCollection: root domains asArray hasSameElements: #( #image #virtualMachine )
 ]
 
 { #category : 'as yet unclassified' }
@@ -61,6 +71,24 @@ CanopyDomainTest >> testMultipleDomainsCoexistIndependently [
 	self assert: (root / #image) value equals: 'image-value'.
 	self assert: (root / #virtualMachine) value equals: 'vm-value'.
 	self assertCollection: root keys asArray hasSameElements: #( image virtualMachine )
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testRegisterDomainAddsNewDomain [
+	| root |
+	root := Canopy new.
+	root registerDomain: #image with: (CanopyCell new value: 1).
+	self assert: (root / #image) value equals: 1.
+	self assert: root domains asArray equals: #( #image )
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testRegisterDomainRaisesOnCollisionAndDoesNotOverwrite [
+	| root |
+	root := Canopy new.
+	root registerDomain: #image with: (CanopyCell new value: 1).
+	self should: [ root registerDomain: #image with: (CanopyCell new value: 2) ] raise: Error.
+	self assert: (root / #image) value equals: 1
 ]
 
 { #category : 'as yet unclassified' }

--- a/source/Canopy-Core/Canopy.class.st
+++ b/source/Canopy-Core/Canopy.class.st
@@ -18,10 +18,20 @@ Canopy class >> /+ aString [
 	^ self instance /+ aString 
 ]
 
+{ #category : 'domains' }
+Canopy class >> domains [
+	^ self instance domains
+]
+
 { #category : 'accessing' }
 Canopy class >> instance [ 
 	^ instance ifNil: [ 
 		instance := self new  ]
+]
+
+{ #category : 'domains' }
+Canopy class >> registerDomain: aSymbol with: aNode [
+	^ self instance registerDomain: aSymbol with: aNode
 ]
 
 { #category : 'initialization' }
@@ -39,4 +49,16 @@ Canopy class >> systemMetrics [
 		at: #virtualMachine addMapping: Smalltalk vm;
 		map 
 	
+]
+
+{ #category : 'domains' }
+Canopy >> domains [
+	^ self keys
+]
+
+{ #category : 'domains' }
+Canopy >> registerDomain: aSymbol with: aNode [
+	(nodes includesKey: aSymbol) ifTrue: [ 
+		^ self error: 'domain ' , aSymbol asString , ' is already registered' ].
+	^ self at: aSymbol put: aNode
 ]


### PR DESCRIPTION
at:put: has no collision guard and is relied on internally for merge mechanics, so it stays as-is. registerDomain:with: is the new, explicit entry point for attaching top-level domains to the Canopy singleton and raises instead of silently overwriting an existing domain. domains lists currently registered top-level domains with domain-specific naming instead of the generic keys/nodes accessors.