### PR TITLE
Fix Canopy apptiveGrid placeholder bug: use real #testServer domain

### DIFF
--- a/source/Canopy-Core-Tests/CanopyBindingTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyBindingTest.class.st
@@ -90,3 +90,18 @@ CanopyBindingTest >> testMultipleAccessorRegistrationsAreAllNotified [
 	self assert: objectA one equals: 99.
 	self assert: objectB one equals: 99
 ]
+
+{ #category : 'as yet unclassified' }
+CanopyBindingTest >> testSetupConfigurationBindsPortFromTestServerDomain [
+	"Regression test for the fixed Canopy apptiveGrid placeholder bug (see Canopy roadmap,
+	Bekannter Bug/Platzhalter: Canopy apptiveGrid nicht definiert). apptiveGrid was never a
+	real domain - it silently resolved to the unrelated Object>>apptiveGrid accessor from
+	Apptive-Common-Core and returned nil instead of raising. Fixed by using the actual
+	#testServer domain this class represents."
+	| server |
+	[ ((Canopy /+ #testServer) /+ #httpServer) at: #port put: (CanopyCell new value: 8080).
+	server := CanopyTestServer new.
+	server setupConfiguration.
+	self assert: server port equals: 8080 ]
+		ensure: [ Canopy reset ]
+]

--- a/source/Canopy-Core-Tests/CanopyTestServer.class.st
+++ b/source/Canopy-Core-Tests/CanopyTestServer.class.st
@@ -21,6 +21,6 @@ CanopyTestServer >> port: anObject [
 ]
 
 { #category : 'as yet unclassified' }
-CanopyTestServer >> setupConfiguration [ 
-	self canopyBind: Canopy apptiveGrid / #httpServer keys: #( port ) 
+CanopyTestServer >> setupConfiguration [
+	self canopyBind: (Canopy / #testServer / #httpServer) keys: #( port )
 ]


### PR DESCRIPTION
CanopyTestServer>>setupConfiguration called Canopy apptiveGrid, which was never a real domain or method on Canopy. It didn't crash because Object (via Apptive-Common-Core, loaded in this shared image) already defines an unrelated apptiveGrid accessor that Canopy inherits, so the call silently returned nil instead of raising - the real domain this class represents is its own test-server config, named #testServer accordingly.