### PR TITLE
Add Canopy class>>attachSystemMetrics as an explicit opt-in

### DIFF
--- a/source/Canopy-Core-Tests/CanopyDomainTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyDomainTest.class.st
@@ -46,6 +46,15 @@ CanopyDomainTest >> testAtPutOnExistingDomainKeyOverwritesWithoutWarning [
 ]
 
 { #category : 'as yet unclassified' }
+CanopyDomainTest >> testAttachSystemMetricsRegistersImageAndVirtualMachineDomains [
+	"attachSystemMetrics is an explicit opt-in, not an automatic image-startup hook (Norbert,
+	2026-07-21: not everyone wants this without being asked) - a caller invokes it themselves."
+	[ Canopy attachSystemMetrics.
+	self assertCollection: Canopy domains asArray hasSameElements: #( #image #virtualMachine ) ]
+		ensure: [ Canopy reset ]
+]
+
+{ #category : 'as yet unclassified' }
 CanopyDomainTest >> testDomainsListsAllRegisteredDomains [
 	| root |
 	root := Canopy new.

--- a/source/Canopy-Core/Canopy.class.st
+++ b/source/Canopy-Core/Canopy.class.st
@@ -19,6 +19,17 @@ Canopy class >> /+ aString [
 ]
 
 { #category : 'domains' }
+Canopy class >> attachSystemMetrics [
+	"Explicit opt-in: attaches the #image/#virtualMachine domains from systemMetrics onto
+	the live singleton. Not wired to any automatic image-startup hook - a caller decides
+	when (or whether) to invoke this."
+	| metrics |
+	metrics := self systemMetrics.
+	self registerDomain: #image with: (metrics / #image).
+	self registerDomain: #virtualMachine with: (metrics / #virtualMachine)
+]
+
+{ #category : 'domains' }
 Canopy class >> domains [
 	^ self instance domains
 ]


### PR DESCRIPTION
systemMetrics already built the #image/#virtualMachine tree, but nothing ever attached it to the live singleton (see Canopy roadmap, Domain-API formalisieren). Deliberately not wired to any automatic image-startup hook - Norbert: not everyone wants this without being asked. A caller invokes attachSystemMetrics themselves when they actually want these domains registered.