### PR TITLE
Clarify domain vs. domain name: domains returns nodes, domainNames th…

### DIFF
--- a/source/Canopy-Core-Tests/CanopyDomainTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyDomainTest.class.st
@@ -35,7 +35,7 @@ CanopyDomainTest >> testAtOperatorCombinesPathAndValue [
 CanopyDomainTest >> testAtPutOnExistingDomainKeyOverwritesWithoutWarning [
 	"at:put: itself intentionally stays ungated — it is also used internally for tree/merge
 	mechanics that rely on overwrite semantics. Callers that want collision protection for
-	top-level domains should use registerDomain:with: instead (see testRegisterDomainRaisesOnCollisionAndDoesNotOverwrite).
+	top-level domains should use registerDomainNamed:with: instead (see testRegisterDomainNamedRaisesOnCollisionAndDoesNotOverwrite).
 	This test documents that at:put: itself still silently overwrites."
 	| root replacement |
 	root := Canopy new.
@@ -46,12 +46,25 @@ CanopyDomainTest >> testAtPutOnExistingDomainKeyOverwritesWithoutWarning [
 ]
 
 { #category : 'as yet unclassified' }
-CanopyDomainTest >> testDomainsListsAllRegisteredDomains [
+CanopyDomainTest >> testDomainNamesListsAllRegisteredDomainNames [
 	| root |
 	root := Canopy new.
-	root registerDomain: #image with: (CanopyCell new value: 1).
-	root registerDomain: #virtualMachine with: (CanopyCell new value: 2).
-	self assertCollection: root domains asArray hasSameElements: #( #image #virtualMachine )
+	root registerDomainNamed: #image with: (CanopyCell new value: 1).
+	root registerDomainNamed: #virtualMachine with: (CanopyCell new value: 2).
+	self assertCollection: root domainNames asArray hasSameElements: #( #image #virtualMachine )
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testDomainsReturnsRegisteredNodes [
+	"domains returns the registered domain nodes themselves (Norbert, 2026-07-21: a domain is
+	what got registered under a name, not the name itself - domainNames is for the names)."
+	| root imageNode vmNode |
+	root := Canopy new.
+	imageNode := CanopyCell new value: 1.
+	vmNode := CanopyCell new value: 2.
+	root registerDomainNamed: #image with: imageNode.
+	root registerDomainNamed: #virtualMachine with: vmNode.
+	self assertCollection: root domains asArray hasSameElements: (Array with: imageNode with: vmNode)
 ]
 
 { #category : 'as yet unclassified' }
@@ -74,27 +87,27 @@ CanopyDomainTest >> testMultipleDomainsCoexistIndependently [
 ]
 
 { #category : 'as yet unclassified' }
-CanopyDomainTest >> testRegisterDomainAddsNewDomain [
+CanopyDomainTest >> testRegisterDomainNamedAddsNewDomain [
 	| root |
 	root := Canopy new.
-	root registerDomain: #image with: (CanopyCell new value: 1).
+	root registerDomainNamed: #image with: (CanopyCell new value: 1).
 	self assert: (root / #image) value equals: 1.
-	self assert: root domains asArray equals: #( #image )
+	self assert: root domainNames asArray equals: #( #image )
 ]
 
 { #category : 'as yet unclassified' }
-CanopyDomainTest >> testRegisterDomainRaisesOnCollisionAndDoesNotOverwrite [
+CanopyDomainTest >> testRegisterDomainNamedRaisesOnCollisionAndDoesNotOverwrite [
 	| root |
 	root := Canopy new.
-	root registerDomain: #image with: (CanopyCell new value: 1).
-	self should: [ root registerDomain: #image with: (CanopyCell new value: 2) ] raise: Error.
+	root registerDomainNamed: #image with: (CanopyCell new value: 1).
+	self should: [ root registerDomainNamed: #image with: (CanopyCell new value: 2) ] raise: Error.
 	self assert: (root / #image) value equals: 1
 ]
 
 { #category : 'as yet unclassified' }
 CanopyDomainTest >> testRegisterImageMetricsRegistersOnlyImageDomain [
 	[ Canopy registerImageMetrics.
-	self assert: Canopy domains asArray equals: #( #image ) ]
+	self assert: Canopy domainNames asArray equals: #( #image ) ]
 		ensure: [ Canopy reset ]
 ]
 
@@ -103,14 +116,14 @@ CanopyDomainTest >> testRegisterSystemMetricsRegistersImageAndVirtualMachineDoma
 	"registerSystemMetrics is an explicit opt-in, not an automatic image-startup hook (Norbert,
 	2026-07-21: not everyone wants this without being asked) - a caller invokes it themselves."
 	[ Canopy registerSystemMetrics.
-	self assertCollection: Canopy domains asArray hasSameElements: #( #image #virtualMachine ) ]
+	self assertCollection: Canopy domainNames asArray hasSameElements: #( #image #virtualMachine ) ]
 		ensure: [ Canopy reset ]
 ]
 
 { #category : 'as yet unclassified' }
 CanopyDomainTest >> testRegisterVirtualMachineMetricsRegistersOnlyVirtualMachineDomain [
 	[ Canopy registerVirtualMachineMetrics.
-	self assert: Canopy domains asArray equals: #( #virtualMachine ) ]
+	self assert: Canopy domainNames asArray equals: #( #virtualMachine ) ]
 		ensure: [ Canopy reset ]
 ]
 

--- a/source/Canopy-Core/Canopy.class.st
+++ b/source/Canopy-Core/Canopy.class.st
@@ -19,6 +19,11 @@ Canopy class >> /+ aString [
 ]
 
 { #category : 'domains' }
+Canopy class >> domainNames [
+	^ self instance domainNames
+]
+
+{ #category : 'domains' }
 Canopy class >> domains [
 	^ self instance domains
 ]
@@ -30,14 +35,14 @@ Canopy class >> instance [
 ]
 
 { #category : 'domains' }
-Canopy class >> registerDomain: aSymbol with: aNode [
-	^ self instance registerDomain: aSymbol with: aNode
+Canopy class >> registerDomainNamed: aSymbol with: aNode [
+	^ self instance registerDomainNamed: aSymbol with: aNode
 ]
 
 { #category : 'domains' }
 Canopy class >> registerImageMetrics [
 	"Explicit opt-in, independently selectable from registerVirtualMachineMetrics."
-	^ self registerDomain: #image with: (self systemMetrics / #image)
+	^ self registerDomainNamed: #image with: (self systemMetrics / #image)
 ]
 
 { #category : 'domains' }
@@ -51,7 +56,7 @@ Canopy class >> registerSystemMetrics [
 { #category : 'domains' }
 Canopy class >> registerVirtualMachineMetrics [
 	"Explicit opt-in, independently selectable from registerImageMetrics."
-	^ self registerDomain: #virtualMachine with: (self systemMetrics / #virtualMachine)
+	^ self registerDomainNamed: #virtualMachine with: (self systemMetrics / #virtualMachine)
 ]
 
 { #category : 'initialization' }
@@ -72,12 +77,17 @@ Canopy class >> systemMetrics [
 ]
 
 { #category : 'domains' }
-Canopy >> domains [
+Canopy >> domainNames [
 	^ self keys
 ]
 
 { #category : 'domains' }
-Canopy >> registerDomain: aSymbol with: aNode [
+Canopy >> domains [
+	^ self nodes values
+]
+
+{ #category : 'domains' }
+Canopy >> registerDomainNamed: aSymbol with: aNode [
 	(nodes includesKey: aSymbol) ifTrue: [ 
 		^ self error: 'domain ' , aSymbol asString , ' is already registered' ].
 	^ self at: aSymbol put: aNode


### PR DESCRIPTION
…e keys

domains previously returned the top-level keys (names), which reads backwards: a domain is what got registered under a name, not the name itself (Norbert). domains now returns the registered domain nodes; domainNames returns the symbols that identify them. registerDomain:with: renamed to registerDomainNamed:with: to make clear its first argument is a name, not a domain.