### PR TITLE
Fix remaining merge conflict asymmetries for Accessor/DictionaryAcces…

### DIFF
--- a/source/Canopy-Core-Tests/CanopyMergeTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyMergeTest.class.st
@@ -63,6 +63,38 @@ CanopyMergeTest >> testDictionaryApplyWithTagOnlyAppliesWhenBranchTagMatches [
 ]
 
 { #category : 'as yet unclassified' }
+CanopyMergeTest >> testMergingAccessorIntoAccessorRaisesConflict [
+	"Verified 2026-07-21: two accessors bound to different live objects have no defined merge
+	semantics - raises a controlled conflict instead of a raw MessageNotUnderstood."
+	| existing incoming |
+	existing := CanopyAccessor new.
+	incoming := CanopyAccessor new.
+	self should: [ existing merge: incoming ] raise: Error
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testMergingAccessorIntoBranchRaisesConflict [
+	"Verified 2026-07-21: before the fix this crashed with a raw MessageNotUnderstood
+	(#mergeInto:) instead of a controlled conflict - CanopyAccessor has no defined merge
+	semantics, merging one into anything never makes sense."
+	| existing incoming |
+	existing := CanopyBranchNode new at: #a put: (CanopyCell new value: 1); yourself.
+	incoming := CanopyAccessor new.
+	self should: [ existing merge: incoming ] raise: Error
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testMergingBranchIntoAccessorRaisesConflict [
+	"Verified 2026-07-21 (Canopy backlog, weitere asymmetrische Typkombinationen): before the
+	fix this crashed with a raw MessageNotUnderstood (#at:add:) instead of a controlled
+	conflict - CanopyAccessor has no defined merge semantics, merging into it never makes sense."
+	| existing incoming |
+	existing := CanopyAccessor new.
+	incoming := CanopyBranchNode new at: #a put: (CanopyCell new value: 1); yourself.
+	self should: [ existing merge: incoming ] raise: Error
+]
+
+{ #category : 'as yet unclassified' }
 CanopyMergeTest >> testMergingBranchIntoCellRaisesConflict [
 	"Fixed 2026-07-21 (Canopy backlog, Merge-Konflikt-Asymmetrie beheben): CanopyCell>>merge:
 	now raises a controlled conflict error when the incoming node is not itself a CanopyCell,
@@ -75,6 +107,17 @@ CanopyMergeTest >> testMergingBranchIntoCellRaisesConflict [
 	existing at: #foo put: (CanopyCell new value: 42).
 	incoming := Canopy new.
 	incoming at: #foo put: CanopyBranchNode new.
+	self should: [ existing merge: incoming ] raise: Error
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMergeTest >> testMergingBranchIntoDictionaryAccessorRaisesConflict [
+	"Same fix, different leaf subtype - confirms the CanopyLeafNode>>mergeInto:/
+	CanopyBranchNode>>mergeInto: guard covers CanopyDictionaryAccessor too, not just
+	CanopyAccessor."
+	| existing incoming |
+	existing := CanopyDictionaryAccessor new.
+	incoming := CanopyBranchNode new at: #a put: (CanopyCell new value: 1); yourself.
 	self should: [ existing merge: incoming ] raise: Error
 ]
 

--- a/source/Canopy-Core/CanopyBranchNode.class.st
+++ b/source/Canopy-Core/CanopyBranchNode.class.st
@@ -167,7 +167,8 @@ CanopyBranchNode >> keysAndValuesDo: aBlock [
 ]
 
 { #category : 'as yet unclassified' }
-CanopyBranchNode >> mergeInto: aGlobBranch [ 
+CanopyBranchNode >> mergeInto: aGlobBranch [
+	(aGlobBranch isKindOf: CanopyBranchNode) ifFalse: [ ^ self error: 'conflict' ].
 	aGlobBranch addTags: tags.
 	nodes keysAndValuesDo: [ :key :value |
 		aGlobBranch at: key add: self / key  ]

--- a/source/Canopy-Core/CanopyLeafNode.class.st
+++ b/source/Canopy-Core/CanopyLeafNode.class.st
@@ -28,6 +28,14 @@ CanopyLeafNode >> inspectionValue [
 	^ self value 
 ]
 
+{ #category : 'actions' }
+CanopyLeafNode >> mergeInto: aGlobValueHolder [
+	"Default conflict for leaf types with no defined merge semantics (Accessor,
+	DictionaryAccessor, Metric - they bind to a live object, merging them makes no sense).
+	CanopyCell overrides this itself since it DOES have real merge semantics."
+	self error: 'conflict'
+]
+
 { #category : 'enumerating' }
 CanopyLeafNode >> recursiveDo: aBlock [ 
 	aBlock value: self 


### PR DESCRIPTION
…sor/Metric

These leaf types have no defined merge semantics (they bind to a live object, not a mergeable value) but previously crashed with a raw MessageNotUnderstood instead of the controlled 'conflict' error CanopyCell already raises: CanopyLeafNode>>mergeInto: (default for leaf types with no merge semantics) fixes the "used as incoming node" case, a guard in CanopyBranchNode>>mergeInto: fixes the "used as existing node, incoming is a branch" case. Verified via Canopy backlog's open item on further asymmetric type combinations.