### PR TITLE
Add CanopyMetricGroup/CanopyMetricMap, wire up dead Prometheus visito…

### DIFF
--- a/source/BaselineOfCanopy/BaselineOfCanopy.class.st
+++ b/source/BaselineOfCanopy/BaselineOfCanopy.class.st
@@ -14,5 +14,6 @@ BaselineOfCanopy >> baseline: spec [
 			spec
 				package: 'Canopy-Core';
 				package: 'Canopy-Metrics'  with: [ spec requires: #('Canopy-Core') ];
-				package: 'Canopy-Core-Tests' with: [ spec requires: #('Canopy-Core') ] ]
+				package: 'Canopy-Core-Tests' with: [ spec requires: #('Canopy-Core') ];
+				package: 'Canopy-Metrics-Tests' with: [ spec requires: #('Canopy-Metrics') ] ]
 ]

--- a/source/Canopy-Core/CanopyLeafNode.class.st
+++ b/source/Canopy-Core/CanopyLeafNode.class.st
@@ -6,8 +6,8 @@ Class {
 }
 
 { #category : 'accessing' }
-CanopyLeafNode class >> withType: aString [ 
-	self subclassesDo: [ :cls |
+CanopyLeafNode class >> withType: aString [
+	self allSubclassesDo: [ :cls |
 		(cls type = aString) ifTrue: [ 
 			^ cls ] ].
 	self error: 'could not find leaf node type ', aString asString

--- a/source/Canopy-Metrics-Tests/CanopyMetricsTestObject.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyMetricsTestObject.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : 'CanopyMetricsTestObject',
+	#superclass : 'Object',
+	#category : 'Canopy-Metrics-Tests',
+	#package : 'Canopy-Metrics-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+CanopyMetricsTestObject >> responsesByStatus [
+	<canopyValue: #responsesByStatus type: #metricMap arguments: #('Responses by status' gauge)>
+	^ Dictionary new at: 200 put: 5; at: 404 put: 2; yourself
+]

--- a/source/Canopy-Metrics-Tests/CanopyMetricsVisitorTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyMetricsVisitorTest.class.st
@@ -1,0 +1,56 @@
+Class {
+	#name : 'CanopyMetricsVisitorTest',
+	#superclass : 'TestCase',
+	#category : 'Canopy-Metrics-Tests',
+	#package : 'Canopy-Metrics-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+CanopyMetricsVisitorTest >> testFormatMetricMapNestedInMetricGroupProducesPerLabelPrometheusLines [
+	"Regression test for the previously dead CanopyPrometheusVisitor>>visitMetricGroup:/
+	visitMetricMap: - CanopyMetricGroup/CanopyMetricMap did not exist before (see Canopy
+	roadmap, Metriken aus pharo-metrics uebernehmen)."
+	| mapBranch metricMap root group output |
+	mapBranch := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	metricMap := mapBranch / #responsesByStatus.
+	root := CanopyBranchNode new.
+	group := CanopyMetricGroup new.
+	root at: #zinc put: group.
+	group at: #responsesByStatus put: metricMap.
+	output := CanopyPrometheusVisitor new format: root.
+	self assert: (output includesSubstring: '# HELP responsesByStatus Responses by status').
+	self assert: (output includesSubstring: '# TYPE responsesByStatus gauge').
+	self assert: (output includesSubstring: 'responsesByStatus{status="200"} 5 ').
+	self assert: (output includesSubstring: 'responsesByStatus{status="404"} 2 ')
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMetricsVisitorTest >> testMetricGroupMetricsReturnsChildNodes [
+	| group a b |
+	group := CanopyMetricGroup new.
+	a := CanopyCell new value: 1.
+	b := CanopyCell new value: 2.
+	group at: #a put: a.
+	group at: #b put: b.
+	self assertCollection: group metrics asArray hasSameElements: (Array with: a with: b)
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMetricsVisitorTest >> testMetricGroupNameReflectsPositionInTree [
+	| root group |
+	root := CanopyBranchNode new.
+	group := CanopyMetricGroup new.
+	root at: #zinc put: group.
+	self assert: group name equals: #zinc
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMetricsVisitorTest >> testMetricMapAttributesAndValuesDoIteratesValueDictionary [
+	| mapBranch metricMap seen |
+	mapBranch := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	metricMap := mapBranch / #responsesByStatus.
+	seen := Dictionary new.
+	metricMap attributesAndValuesDo: [ :status :count | seen at: status put: count ].
+	self assert: (seen at: 200) equals: 5.
+	self assert: (seen at: 404) equals: 2
+]

--- a/source/Canopy-Metrics-Tests/package.st
+++ b/source/Canopy-Metrics-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Canopy-Metrics-Tests' }

--- a/source/Canopy-Metrics/CanopyMetricGroup.class.st
+++ b/source/Canopy-Metrics/CanopyMetricGroup.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : 'CanopyMetricGroup',
+	#superclass : 'CanopyBranchNode',
+	#category : 'Canopy-Metrics',
+	#package : 'Canopy-Metrics'
+}
+
+{ #category : 'visiting' }
+CanopyMetricGroup >> acceptCanopy: aVisitor [
+	aVisitor visitMetricGroup: self
+]
+
+{ #category : 'accessing' }
+CanopyMetricGroup >> metrics [
+	^ self nodes values
+]
+
+{ #category : 'accessing' }
+CanopyMetricGroup >> name [
+	^ self key
+]

--- a/source/Canopy-Metrics/CanopyMetricMap.class.st
+++ b/source/Canopy-Metrics/CanopyMetricMap.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'CanopyMetricMap',
+	#superclass : 'CanopyMetric',
+	#category : 'Canopy-Metrics',
+	#package : 'Canopy-Metrics'
+}
+
+{ #category : 'accessing' }
+CanopyMetricMap class >> type [
+	^ #metricMap
+]
+
+{ #category : 'visiting' }
+CanopyMetricMap >> acceptCanopy: aVisitor [
+	aVisitor visitMetricMap: self
+]
+
+{ #category : 'accessing' }
+CanopyMetricMap >> attributes [
+	^ self properties
+]
+
+{ #category : 'accessing' }
+CanopyMetricMap >> attributesAndValuesDo: aBlock [
+	self value keysAndValuesDo: aBlock
+]


### PR DESCRIPTION
…r methods

CanopyPrometheusVisitor>>visitMetricGroup:/visitMetricMap: were written but referenced classes that never existed. CanopyMetricGroup (subclass of CanopyBranchNode, exposes name/metrics for the visitor) and CanopyMetricMap (subclass of CanopyMetric, exposes attributes/attributesAndValuesDo: for labeled values like "responses by status code") make them work end to end - verified via a new Canopy-Metrics-Tests package with a real pragma-tagged test object round-tripped through format:.

CanopyLeafNode class>>withType: switched from subclassesDo: to allSubclassesDo:, since CanopyMetricMap sits one level below CanopyLeafNode (under CanopyMetric) and the pragma-based construction path needs to find it there.