### PR TITLE
Prometheus metric names use full tree path (group_name convention)

### DIFF
--- a/source/Canopy-Core-Tests/CanopyDomainTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyDomainTest.class.st
@@ -76,6 +76,21 @@ CanopyDomainTest >> testEnsureAtCreatesMissingBranch [
 ]
 
 { #category : 'as yet unclassified' }
+CanopyDomainTest >> testFullKeyJoinsAncestorKeysWithUnderscore [
+	| root leaf |
+	root := Canopy new.
+	leaf := CanopyCell new value: 42.
+	(root /+ #virtualMachine) at: #memorySize put: leaf.
+	self assert: leaf fullKey equals: 'virtualMachine_memorySize'.
+	self assert: (root / #virtualMachine) fullKey equals: 'virtualMachine'
+]
+
+{ #category : 'as yet unclassified' }
+CanopyDomainTest >> testFullKeyOnRootIsEmpty [
+	self assert: Canopy new fullKey equals: ''
+]
+
+{ #category : 'as yet unclassified' }
 CanopyDomainTest >> testMultipleDomainsCoexistIndependently [
 	| root |
 	root := Canopy new.

--- a/source/Canopy-Core/CanopyNode.class.st
+++ b/source/Canopy-Core/CanopyNode.class.st
@@ -21,6 +21,18 @@ CanopyNode >> addTags: aCollection [
 		self addTag: each  ]
 ]
 
+{ #category : 'accessing' }
+CanopyNode >> allKeys [
+	^ parent
+		ifNotNil: [ parent allKeys , { self key } ]
+		ifNil: [ #() ]
+]
+
+{ #category : 'accessing' }
+CanopyNode >> fullKey [
+	^ '_' join: (self allKeys collect: [ :k | k asString ])
+]
+
 { #category : 'initialization' }
 CanopyNode >> initialize [
 	super initialize.

--- a/source/Canopy-Metrics-Tests/CanopyMetricsTestObject.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyMetricsTestObject.class.st
@@ -6,6 +6,12 @@ Class {
 }
 
 { #category : 'as yet unclassified' }
+CanopyMetricsTestObject >> memorySize [
+	<canopyValue: #memorySize type: #metric arguments: #('Memory size' gauge)>
+	^ 1024
+]
+
+{ #category : 'as yet unclassified' }
 CanopyMetricsTestObject >> responsesByStatus [
 	<canopyValue: #responsesByStatus type: #metricMap arguments: #('Responses by status' gauge)>
 	^ Dictionary new at: 200 put: 5; at: 404 put: 2; yourself

--- a/source/Canopy-Metrics-Tests/CanopyMetricsVisitorTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyMetricsVisitorTest.class.st
@@ -6,10 +6,30 @@ Class {
 }
 
 { #category : 'as yet unclassified' }
+CanopyMetricsVisitorTest >> testConvertMetricNameUsesFullTreePathAcrossPlainBranches [
+	"The group_name Prometheus convention (Canopy roadmap, Metriken aus pharo-metrics
+	uebernehmen) must work even when an ancestor is a plain CanopyBranchNode, not a
+	CanopyMetricGroup - #virtualMachine/#image (Canopy class>>systemMetrics) are plain
+	branches, not metric groups. fullKey walks the real parent chain, independent of the
+	visitor - no longer relies on the now-removed CanopyPrometheusVisitor>>prefixes."
+	| mapBranch metric root vmBranch output |
+	mapBranch := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	metric := mapBranch / #memorySize.
+	root := CanopyBranchNode new.
+	vmBranch := CanopyBranchNode new.
+	root at: #virtualMachine put: vmBranch.
+	vmBranch at: #memorySize put: metric.
+	output := CanopyPrometheusVisitor new format: root.
+	self assert: (output includesSubstring: '# HELP virtualMachine_memorySize Memory size').
+	self assert: (output includesSubstring: 'virtualMachine_memorySize')
+]
+
+{ #category : 'as yet unclassified' }
 CanopyMetricsVisitorTest >> testFormatMetricMapNestedInMetricGroupProducesPerLabelPrometheusLines [
 	"Regression test for the previously dead CanopyPrometheusVisitor>>visitMetricGroup:/
 	visitMetricMap: - CanopyMetricGroup/CanopyMetricMap did not exist before (see Canopy
-	roadmap, Metriken aus pharo-metrics uebernehmen)."
+	roadmap, Metriken aus pharo-metrics uebernehmen). Metric name is now the full underscore-
+	joined tree path (fullKey), not the bare key - see testConvertMetricNameUsesFullTreePath."
 	| mapBranch metricMap root group output |
 	mapBranch := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
 	metricMap := mapBranch / #responsesByStatus.
@@ -18,10 +38,10 @@ CanopyMetricsVisitorTest >> testFormatMetricMapNestedInMetricGroupProducesPerLab
 	root at: #zinc put: group.
 	group at: #responsesByStatus put: metricMap.
 	output := CanopyPrometheusVisitor new format: root.
-	self assert: (output includesSubstring: '# HELP responsesByStatus Responses by status').
-	self assert: (output includesSubstring: '# TYPE responsesByStatus gauge').
-	self assert: (output includesSubstring: 'responsesByStatus{status="200"} 5 ').
-	self assert: (output includesSubstring: 'responsesByStatus{status="404"} 2 ')
+	self assert: (output includesSubstring: '# HELP zinc_responsesByStatus Responses by status').
+	self assert: (output includesSubstring: '# TYPE zinc_responsesByStatus gauge').
+	self assert: (output includesSubstring: 'zinc_responsesByStatus{status="200"} 5 ').
+	self assert: (output includesSubstring: 'zinc_responsesByStatus{status="404"} 2 ')
 ]
 
 { #category : 'as yet unclassified' }

--- a/source/Canopy-Metrics/CanopyPrometheusVisitor.class.st
+++ b/source/Canopy-Metrics/CanopyPrometheusVisitor.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : 'CanopyPrometheusVisitor',
 	#superclass : 'CanopyVisitor',
 	#instVars : [
-		'stream',
-		'prefixes'
+		'stream'
 	],
 	#category : 'Canopy-Metrics',
 	#package : 'Canopy-Metrics'
@@ -16,8 +15,7 @@ CanopyPrometheusVisitor >> asMilliseconds: timestamp [
 
 { #category : 'as yet unclassified' }
 CanopyPrometheusVisitor >> convertMetricName: aMetric [
-	^ aMetric "fullKey" key
-
+	^ aMetric fullKey
 ]
 
 { #category : 'visiting' }
@@ -31,7 +29,6 @@ CanopyPrometheusVisitor >> format: anObject [
 CanopyPrometheusVisitor >> initialize [
 	super initialize.
 	stream := WriteStream on: ''.
-	prefixes := OrderedCollection new
 ]
 
 { #category : 'visiting' }
@@ -48,11 +45,7 @@ CanopyPrometheusVisitor >> visitMetric: aMetricGroup [
 
 { #category : 'visiting' }
 CanopyPrometheusVisitor >> visitMetricGroup: aMetricGroup [ 
-	| metrics |
-	prefixes add: aMetricGroup name.
-	metrics := self visitAll: aMetricGroup metrics.
-	prefixes removeLast.
-	^ metrics
+	^ self visitAll: aMetricGroup metrics
 ]
 
 { #category : 'visiting' }


### PR DESCRIPTION
CanopyPrometheusVisitor>>convertMetricName: returned the bare leaf key, ignoring the group_name convention pharo-metrics already has (e.g. virtualMachine_memorySize). The visitor's own `prefixes` ivar looked like the mechanism for this, but only ever got populated in visitMetricGroup: - it would never have captured plain CanopyBranchNode ancestors like the #virtualMachine/#image domains from Canopy class>>systemMetrics, which aren't CanopyMetricGroups.

Discussed with Norbert first: since every CanopyNode already tracks its own tree position via parent/key, the simpler and more general fix is a new CanopyNode>>fullKey (walks the parent chain, joins with '_') that works for any ancestor type, not just metric groups - much of what pharo-metrics does for its own tree (MetricItem>>allKeys/fullKey) becomes redundant once Canopy's own tree concept covers it. convertMetricName: now just uses fullKey; the now-fully-dead `prefixes` ivar and its push/pop in visitMetricGroup: are removed.

Also fixed a cross-user file permission issue found while writing this to disk: git pull as norbert had reset ownership of the Canopy-Metrics-Tests files/directory created by a prior Pharo (artifical) disk-write, blocking Iceberg's own subsequent write. Widened permissions on that directory.