### PR TITLE
Fix misleading duplicate description and typo in VM/Image metric pragmas

### DIFF
--- a/source/Canopy-Metrics-Tests/CanopyMetricsVisitorTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyMetricsVisitorTest.class.st
@@ -25,6 +25,20 @@ CanopyMetricsVisitorTest >> testConvertMetricNameUsesFullTreePathAcrossPlainBran
 ]
 
 { #category : 'as yet unclassified' }
+CanopyMetricsVisitorTest >> testExternalObjectMetricsHaveDistinctDescriptions [
+	"Fixed 2026-07-21: externalObjectTableSizeCanopy/externalObjectsCanopy (and their
+	pharo-metrics siblings, out of scope here per Norbert - only the Canopy pragmas in
+	this repo matter, pharo-metrics is not loaded once Canopy replaces it) shared the exact
+	same description despite measuring different things: total table size (including free
+	slots) vs. count of currently registered (non-nil) objects."
+	| metrics tableSize objects |
+	metrics := Canopy systemMetrics.
+	tableSize := metrics / #image / #externalObjectTableSize.
+	objects := metrics / #image / #externalObjects.
+	self deny: tableSize description equals: objects description
+]
+
+{ #category : 'as yet unclassified' }
 CanopyMetricsVisitorTest >> testFormatMetricMapNestedInMetricGroupProducesPerLabelPrometheusLines [
 	"Regression test for the previously dead CanopyPrometheusVisitor>>visitMetricGroup:/
 	visitMetricMap: - CanopyMetricGroup/CanopyMetricMap did not exist before (see Canopy

--- a/source/Canopy-Metrics/ExternalSemaphoreTable.extension.st
+++ b/source/Canopy-Metrics/ExternalSemaphoreTable.extension.st
@@ -2,12 +2,12 @@ Extension { #name : 'ExternalSemaphoreTable' }
 
 { #category : '*Canopy-Metrics' }
 ExternalSemaphoreTable class >> externalObjectTableSizeCanopy [
-	<canopyValue: #externalObjectTableSize type: #metric arguments: #('The number of registered external objects' gauge)>
+	<canopyValue: #externalObjectTableSize type: #metric arguments: #('The total size of the external object table, including free slots' gauge)>
 	^ self externalObjects size
 ]
 
 { #category : '*Canopy-Metrics' }
-ExternalSemaphoreTable class >> externalObjectsCanopy [ 
-	<canopyValue: #externalObjects type: #metric arguments: #('The number of registered external objects' gauge)>
+ExternalSemaphoreTable class >> externalObjectsCanopy [
+	<canopyValue: #externalObjects type: #metric arguments: #('The number of currently registered (non-nil) external objects' gauge)>
 	^ (self externalObjects reject: #isNil) size
 ]

--- a/source/Canopy-Metrics/VirtualMachine.extension.st
+++ b/source/Canopy-Metrics/VirtualMachine.extension.st
@@ -73,7 +73,7 @@ VirtualMachine >> tenureCountCanopy [
 ]
 
 { #category : '*Canopy-Metrics' }
-VirtualMachine >> totalFullGCTimetCanopy [
+VirtualMachine >> totalFullGCTimeCanopy [
 	<canopyValue: #totalFullGCTime type: #metric arguments: #('The amount of time for a full GC' gauge)>
 	^ self totalFullGCTime
 ]


### PR DESCRIPTION
Scoped to the Canopy-side pragmas only (Norbert: pharo-metrics itself is out of scope, it stops being loaded once Canopy replaces it) - checked all VM/Image values Canopy already ports (VirtualMachine, Process, File, ExternalSemaphoreTable): every value from the roadmap's list already has a Canopy pragma method, so there was nothing left to port. Found two issues while reviewing them:

- externalObjectTableSizeCanopy/externalObjectsCanopy shared the exact same description despite measuring different things (total table size including free slots vs. count of currently registered objects).
- totalFullGCTimetCanopy had a typo in its selector name (mirrored from the pharo-metrics method it was based on) - renamed, the canopy tree key itself (#totalFullGCTime) was already correct so this has no external effect.