### PR TITLE
Add CanopyZincCounter for Zinc/HTTP request metrics

### DIFF
--- a/source/Canopy-Core/Canopy.class.st
+++ b/source/Canopy-Core/Canopy.class.st
@@ -59,6 +59,15 @@ Canopy class >> registerVirtualMachineMetrics [
 	^ self registerDomainNamed: #virtualMachine with: (self systemMetrics / #virtualMachine)
 ]
 
+{ #category : 'domains' }
+Canopy class >> registerZincMetrics [
+	"Explicit opt-in - subscribes CanopyZincCounter to live Zinc server traffic and registers
+	the #zinc domain. Not wired to any automatic image-startup hook, same reasoning as
+	registerSystemMetrics: not everyone wants this without being asked."
+	CanopyZincCounter install.
+	^ self registerDomainNamed: #zinc with: (self zincMetrics / #zinc)
+]
+
 { #category : 'initialization' }
 Canopy class >> reset [ 
 	instance := nil 
@@ -74,6 +83,13 @@ Canopy class >> systemMetrics [
 		at: #virtualMachine addMapping: Smalltalk vm;
 		map 
 	
+]
+
+{ #category : 'metrics' }
+Canopy class >> zincMetrics [
+	^ CanopyMappingBuilder new
+		at: #zinc addMapping: CanopyZincCounter instance;
+		map
 ]
 
 { #category : 'domains' }

--- a/source/Canopy-Metrics-Tests/CanopyZincCounterTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyZincCounterTest.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : 'CanopyZincCounterTest',
+	#superclass : 'TestCase',
+	#category : 'Canopy-Metrics-Tests',
+	#package : 'Canopy-Metrics-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+CanopyZincCounterTest >> testHandleAnnouncementAdjustsDurationWithExponentialMovingAverage [
+	"Mirrors ZincCounter (pharo-metrics, out of scope otherwise): first duration sets the
+	baseline, subsequent durations are folded in with 99% weight on the running average."
+	[ CanopyZincCounter reset.
+	CanopyZincCounter instance handleAnnouncement: (CanopyZincTestAnnouncement new responseCode: 200 duration: 10; yourself).
+	self assert: CanopyZincCounter instance duration equals: 10.
+	CanopyZincCounter instance handleAnnouncement: (CanopyZincTestAnnouncement new responseCode: 200 duration: 20; yourself).
+	self assert: CanopyZincCounter instance duration equals: (((99 * 10) + 20) / 100) asInteger ]
+		ensure: [ CanopyZincCounter reset ]
+]
+
+{ #category : 'as yet unclassified' }
+CanopyZincCounterTest >> testHandleAnnouncementIncrementsRequestsAndStatusCounts [
+	[ CanopyZincCounter reset.
+	CanopyZincCounter instance handleAnnouncement: (CanopyZincTestAnnouncement new responseCode: 200 duration: 10; yourself).
+	CanopyZincCounter instance handleAnnouncement: (CanopyZincTestAnnouncement new responseCode: 200 duration: 10; yourself).
+	CanopyZincCounter instance handleAnnouncement: (CanopyZincTestAnnouncement new responseCode: 404 duration: 10; yourself).
+	self assert: CanopyZincCounter instance requests equals: 3.
+	self assert: (CanopyZincCounter instance responses at: 200) equals: 2.
+	self assert: (CanopyZincCounter instance responses at: 404) equals: 1 ]
+		ensure: [ CanopyZincCounter reset ]
+]
+
+{ #category : 'as yet unclassified' }
+CanopyZincCounterTest >> testRegisterZincMetricsRegistersZincDomainWithExpectedValues [
+	"End-to-end: registerZincMetrics installs CanopyZincCounter (subscribes to live Zinc
+	server traffic - independent of pharo-metrics, per Norbert 2026-07-21) and registers
+	#zinc as a Canopy domain. Values fed in directly rather than via a real HTTP request."
+	| output |
+	[ CanopyZincCounter reset.
+	CanopyZincCounter instance handleAnnouncement: (CanopyZincTestAnnouncement new responseCode: 200 duration: 10; yourself).
+	CanopyZincCounter instance handleAnnouncement: (CanopyZincTestAnnouncement new responseCode: 404 duration: 20; yourself).
+	Canopy registerZincMetrics.
+	output := CanopyPrometheusVisitor new format: Canopy instance.
+	self assert: (output includesSubstring: 'zinc_httpRequests{} 2 ').
+	self assert: (output includesSubstring: 'zinc_httpResponses{status="200"} 1 ').
+	self assert: (output includesSubstring: 'zinc_httpResponses{status="404"} 1 ').
+	self assert: (output includesSubstring: '# HELP zinc_duration Average duration of requests') ]
+		ensure: [ CanopyZincCounter instance uninstall. Canopy reset. CanopyZincCounter reset ]
+]

--- a/source/Canopy-Metrics-Tests/CanopyZincTestAnnouncement.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyZincTestAnnouncement.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'CanopyZincTestAnnouncement',
+	#superclass : 'Object',
+	#instVars : [
+		'responseCode',
+		'duration'
+	],
+	#category : 'Canopy-Metrics-Tests',
+	#package : 'Canopy-Metrics-Tests'
+}
+
+{ #category : 'accessing' }
+CanopyZincTestAnnouncement >> duration [
+	^ duration
+]
+
+{ #category : 'accessing' }
+CanopyZincTestAnnouncement >> responseCode [
+	^ responseCode
+]
+
+{ #category : 'accessing' }
+CanopyZincTestAnnouncement >> responseCode: aCode duration: aDuration [
+	responseCode := aCode.
+	duration := aDuration
+]

--- a/source/Canopy-Metrics/CanopyZincCounter.class.st
+++ b/source/Canopy-Metrics/CanopyZincCounter.class.st
@@ -1,0 +1,113 @@
+Class {
+	#name : 'CanopyZincCounter',
+	#superclass : 'Object',
+	#instVars : [
+		'requests',
+		'responses',
+		'duration',
+		'registration'
+	],
+	#classInstVars : [
+		'instance'
+	],
+	#category : 'Canopy-Metrics',
+	#package : 'Canopy-Metrics'
+}
+
+{ #category : 'installing' }
+CanopyZincCounter class >> install [
+	^ self instance install
+]
+
+{ #category : 'accessing' }
+CanopyZincCounter class >> instance [
+	^ instance ifNil: [ instance := self new ]
+]
+
+{ #category : 'initialization' }
+CanopyZincCounter class >> reset [
+	instance := nil
+]
+
+{ #category : 'installing' }
+CanopyZincCounter class >> uninstall [
+	^ self instance uninstall
+]
+
+{ #category : 'counting' }
+CanopyZincCounter >> adjustDuration: aDuration [
+	duration ifNil: [ ^ duration := aDuration ].
+	duration := (((99 * duration) + aDuration) / 100) asInteger
+]
+
+{ #category : 'accessing' }
+CanopyZincCounter >> duration [
+	^ duration
+]
+
+{ #category : 'as yet unclassified' }
+CanopyZincCounter >> durationCanopy [
+	<canopyValue: #duration type: #metric arguments: #('Average duration of requests' gauge)>
+	^ self duration
+]
+
+{ #category : 'counting' }
+CanopyZincCounter >> handleAnnouncement: anAnnouncement [
+	self increaseRequests.
+	self increaseStatusCode: anAnnouncement responseCode.
+	self adjustDuration: anAnnouncement duration
+]
+
+{ #category : 'counting' }
+CanopyZincCounter >> increaseRequests [
+	requests := requests + 1
+]
+
+{ #category : 'counting' }
+CanopyZincCounter >> increaseStatusCode: statusCode [
+	| count |
+	count := responses at: statusCode ifAbsent: [ 0 ].
+	responses at: statusCode put: count + 1
+]
+
+{ #category : 'initialization' }
+CanopyZincCounter >> initialize [
+	super initialize.
+	requests := 0.
+	responses := Dictionary new
+]
+
+{ #category : 'installing' }
+CanopyZincCounter >> install [
+	registration := ZnLogEvent announcer
+		when: ZnSimplifiedServerTransactionEvent
+		do: [ :ann | self handleAnnouncement: ann ]
+		for: self
+]
+
+{ #category : 'accessing' }
+CanopyZincCounter >> requests [
+	^ requests
+]
+
+{ #category : 'as yet unclassified' }
+CanopyZincCounter >> requestsCanopy [
+	<canopyValue: #httpRequests type: #metric arguments: #('Number of requests' counter)>
+	^ self requests
+]
+
+{ #category : 'accessing' }
+CanopyZincCounter >> responses [
+	^ responses
+]
+
+{ #category : 'as yet unclassified' }
+CanopyZincCounter >> responsesCanopy [
+	<canopyValue: #httpResponses type: #metricMap arguments: #('Number of responses by status' counter)>
+	^ self responses
+]
+
+{ #category : 'installing' }
+CanopyZincCounter >> uninstall [
+	ZnLogEvent announcer unsubscribe: self
+]


### PR DESCRIPTION
Builds Requests, Responses-by-status (as a CanopyMetricMap), and average request duration for Canopy's own pragma convention - the Zinc/HTTP leg of "Metriken aus pharo-metrics uebernehmen" that was still completely missing.

Deliberately does NOT extend pharo-metrics' own ZincCounter, unlike the VM/Image metrics: ZincCounter lives in pharo-metrics itself (Metrics-Zinc), which stops being loaded once Canopy replaces it (Norbert). CanopyZincCounter re-subscribes directly to ZnLogEvent/ZnSimplifiedServerTransactionEvent - a Zinc-HTTP framework facility, not a pharo-metrics one - so it has no dependency on the library it's meant to make obsolete.

Canopy class>>registerZincMetrics is an explicit opt-in (installs the subscription, registers the #zinc domain), same reasoning as registerSystemMetrics: not everyone wants live traffic counting without being asked.