### PR TITLE
Add memory-limit/usage-percentage read-write leaf example

### DIFF
--- a/source/Canopy-Core-Tests/CanopyMemoryLimitExampleObject.class.st
+++ b/source/Canopy-Core-Tests/CanopyMemoryLimitExampleObject.class.st
@@ -1,0 +1,38 @@
+Class {
+	#name : 'CanopyMemoryLimitExampleObject',
+	#superclass : 'Object',
+	#instVars : [
+		'memoryLimit',
+		'usedMemory'
+	],
+	#category : 'Canopy-Core-Tests',
+	#package : 'Canopy-Core-Tests'
+}
+
+{ #category : 'accessing' }
+CanopyMemoryLimitExampleObject >> memoryLimit [
+	<canopyValue: #memoryLimit type: #accessor arguments: #()>
+	^ memoryLimit
+]
+
+{ #category : 'accessing' }
+CanopyMemoryLimitExampleObject >> memoryLimit: anInteger [
+	memoryLimit := anInteger
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMemoryLimitExampleObject >> usagePercentageCanopy [
+	<canopyValue: #usagePercentage type: #metric arguments: #('Percentage of the configured memory limit currently in use' gauge)>
+	^ (usedMemory / memoryLimit) * 100
+]
+
+{ #category : 'accessing' }
+CanopyMemoryLimitExampleObject >> usedMemory: anInteger [
+	usedMemory := anInteger
+]
+
+{ #category : 'as yet unclassified' }
+CanopyMemoryLimitExampleObject >> usedMemoryCanopy [
+	<canopyValue: #usedMemory type: #metric arguments: #('Currently used memory' gauge)>
+	^ usedMemory
+]

--- a/source/Canopy-Metrics-Tests/CanopyReadWriteLeafExampleTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyReadWriteLeafExampleTest.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'CanopyReadWriteLeafExampleTest',
+	#superclass : 'TestCase',
+	#category : 'Canopy-Metrics-Tests',
+	#package : 'Canopy-Metrics-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+CanopyReadWriteLeafExampleTest >> testConfiguredLimitAndLiveUsageProduceExportedPercentage [
+	"Leitbeispiel aus Canopy roadmap, Terminologie Accessor/Metric-Richtungsambiguitaet: ein
+	konfiguriertes Memory-Limit (write Canopy -> component, ueber den #accessor-Pragma-Pfad)
+	sitzt neben einem laufend erzeugten aktuell-genutzt-Wert (read component -> Canopy, ueber
+	den #metric-Pfad) auf demselben Objekt, gebaut in einem einzigen Pragma-Reflection-Durchlauf
+	- genau wofuer die Accessor/Metric-Vereinheitlichung (PR #19) gedacht war. Eine daraus
+	abgeleitete Nutzungs-Prozentzahl wird genauso exportiert wie jede andere Metrik."
+	| object tree output |
+	object := CanopyMemoryLimitExampleObject new.
+	object canopySetupFrom: '{ "memoryLimit": 1000 }'.
+	object usedMemory: 250.
+	tree := object canopyMapping.
+	self assert: object memoryLimit equals: 1000.
+	self assert: (tree / #usedMemory) value equals: 250.
+	self assert: (tree / #usagePercentage) value equals: 25.
+	output := CanopyPrometheusVisitor new format: tree.
+	self assert: (output includesSubstring: 'usagePercentage{} 25 ')
+]


### PR DESCRIPTION
Demonstrates the roadmap's guiding example for the Accessor/Metric unification (PR #19): a configured memory limit (write direction, Canopy -> component, via the #accessor pragma) and a live "currently used" value (read direction, component -> Canopy, via #metric) coexist on the same object, built in a single pragma-reflection pass. A derived usage percentage combining both is exported through CanopyPrometheusVisitor exactly like any other metric.