### PR TITLE
Decentralize domain registration via canopyRegister, verify canopyBra…

### DIFF
--- a/source/Canopy-Core-Tests/CanopyComposedAppExample.class.st
+++ b/source/Canopy-Core-Tests/CanopyComposedAppExample.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'CanopyComposedAppExample',
+	#superclass : 'Object',
+	#instVars : [
+		'componentA',
+		'componentB'
+	],
+	#category : 'Canopy-Core-Tests',
+	#package : 'Canopy-Core-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+CanopyComposedAppExample >> canopyBranch: aBuilder [
+	<canopyBranch>
+	aBuilder at: #componentA addMapping: componentA.
+	aBuilder at: #componentB addMapping: componentB
+]
+
+{ #category : 'accessing' }
+CanopyComposedAppExample >> componentA [
+	^ componentA
+]
+
+{ #category : 'accessing' }
+CanopyComposedAppExample >> componentB [
+	^ componentB
+]
+
+{ #category : 'initialization' }
+CanopyComposedAppExample >> initialize [
+	super initialize.
+	componentA := CanopyComposedSubComponent new.
+	componentB := CanopyComposedSubComponent new
+]

--- a/source/Canopy-Core-Tests/CanopyComposedSubComponent.class.st
+++ b/source/Canopy-Core-Tests/CanopyComposedSubComponent.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'CanopyComposedSubComponent',
+	#superclass : 'Object',
+	#instVars : [
+		'value'
+	],
+	#category : 'Canopy-Core-Tests',
+	#package : 'Canopy-Core-Tests'
+}
+
+{ #category : 'accessing' }
+CanopyComposedSubComponent >> value: anInteger [
+	value := anInteger
+]
+
+{ #category : 'as yet unclassified' }
+CanopyComposedSubComponent >> valueCanopy [
+	<canopyValue: #value type: #metric arguments: #('A sub-component value' gauge)>
+	^ value
+]

--- a/source/Canopy-Core/Canopy.class.st
+++ b/source/Canopy-Core/Canopy.class.st
@@ -41,8 +41,10 @@ Canopy class >> registerDomainNamed: aSymbol with: aNode [
 
 { #category : 'domains' }
 Canopy class >> registerImageMetrics [
-	"Explicit opt-in, independently selectable from registerVirtualMachineMetrics."
-	^ self registerDomainNamed: #image with: (self systemMetrics / #image)
+	SmalltalkImage canopyRegister.
+	Process canopyRegister.
+	File canopyRegister.
+	ExternalSemaphoreTable canopyRegister
 ]
 
 { #category : 'domains' }
@@ -55,8 +57,7 @@ Canopy class >> registerSystemMetrics [
 
 { #category : 'domains' }
 Canopy class >> registerVirtualMachineMetrics [
-	"Explicit opt-in, independently selectable from registerImageMetrics."
-	^ self registerDomainNamed: #virtualMachine with: (self systemMetrics / #virtualMachine)
+	^ VirtualMachine canopyRegister
 ]
 
 { #category : 'domains' }
@@ -64,32 +65,12 @@ Canopy class >> registerZincMetrics [
 	"Explicit opt-in - subscribes CanopyZincCounter to live Zinc server traffic and registers
 	the #zinc domain. Not wired to any automatic image-startup hook, same reasoning as
 	registerSystemMetrics: not everyone wants this without being asked."
-	CanopyZincCounter install.
-	^ self registerDomainNamed: #zinc with: (self zincMetrics / #zinc)
+	^ CanopyZincCounter canopyRegister
 ]
 
 { #category : 'initialization' }
 Canopy class >> reset [ 
 	instance := nil 
-]
-
-{ #category : 'as yet unclassified' }
-Canopy class >> systemMetrics [ 
-	^ CanopyMappingBuilder new 
-		at: #image addMapping: Smalltalk;  
-		at: #image addMapping: Process;
-		at: #image addMapping: File;
-		at: #image addMapping: ExternalSemaphoreTable;
-		at: #virtualMachine addMapping: Smalltalk vm;
-		map 
-	
-]
-
-{ #category : 'metrics' }
-Canopy class >> zincMetrics [
-	^ CanopyMappingBuilder new
-		at: #zinc addMapping: CanopyZincCounter instance;
-		map
 ]
 
 { #category : 'domains' }

--- a/source/Canopy-Metrics-Tests/CanopyMetricsVisitorTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyMetricsVisitorTest.class.st
@@ -32,10 +32,12 @@ CanopyMetricsVisitorTest >> testExternalObjectMetricsHaveDistinctDescriptions [
 	same description despite measuring different things: total table size (including free
 	slots) vs. count of currently registered (non-nil) objects."
 	| metrics tableSize objects |
-	metrics := Canopy systemMetrics.
+	[ ExternalSemaphoreTable canopyRegister.
+	metrics := Canopy instance.
 	tableSize := metrics / #image / #externalObjectTableSize.
 	objects := metrics / #image / #externalObjects.
-	self deny: tableSize description equals: objects description
+	self deny: tableSize description equals: objects description ]
+		ensure: [ Canopy reset ]
 ]
 
 { #category : 'as yet unclassified' }

--- a/source/Canopy-Metrics-Tests/CanopyReadWriteLeafExampleTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyReadWriteLeafExampleTest.class.st
@@ -6,6 +6,28 @@ Class {
 }
 
 { #category : 'as yet unclassified' }
+CanopyReadWriteLeafExampleTest >> testComposedInstanceRegistersAsDomainViaCanopyBranch [
+	"Antwort auf die Instanz-basierte Haelfte der Registrierungsmechanismus-Frage (siehe
+	Canopy backlog, Registrierungsmechanismus): eine komponierte Instanz baut ueber ihre
+	eigene <canopyBranch>-Methode eine komponierte Struktur aus mehreren Sub-Komponenten,
+	die per canopyMapping + registerDomainNamed:with: als eigene Domain in Canopy landet -
+	kein neuer Mechanismus noetig, canopyBranch war schon da (bisher nur an Dictionary
+	demonstriert, siehe Canopy doc). fullKey loest auch ueber zwei Verschachtelungsebenen
+	korrekt auf (myApp_componentA_value)."
+	| app output |
+	[ app := CanopyComposedAppExample new.
+	app componentA value: 10.
+	app componentB value: 20.
+	Canopy registerDomainNamed: #myApp with: app canopyMapping.
+	self assert: (Canopy / #myApp / #componentA / #value) value equals: 10.
+	self assert: (Canopy / #myApp / #componentB / #value) value equals: 20.
+	output := CanopyPrometheusVisitor new format: Canopy instance.
+	self assert: (output includesSubstring: 'myApp_componentA_value{} 10 ').
+	self assert: (output includesSubstring: 'myApp_componentB_value{} 20 ') ]
+		ensure: [ Canopy reset ]
+]
+
+{ #category : 'as yet unclassified' }
 CanopyReadWriteLeafExampleTest >> testConfiguredLimitAndLiveUsageProduceExportedPercentage [
 	"Leitbeispiel aus Canopy roadmap, Terminologie Accessor/Metric-Richtungsambiguitaet: ein
 	konfiguriertes Memory-Limit (write Canopy -> component, ueber den #accessor-Pragma-Pfad)

--- a/source/Canopy-Metrics/CanopyZincCounter.class.st
+++ b/source/Canopy-Metrics/CanopyZincCounter.class.st
@@ -15,6 +15,12 @@ Class {
 }
 
 { #category : 'installing' }
+CanopyZincCounter class >> canopyRegister [
+	self install.
+	^ Canopy registerDomainNamed: #zinc with: (CanopyMappingBuilder new object: self instance; map: CanopyBranchNode new; build)
+]
+
+{ #category : 'installing' }
 CanopyZincCounter class >> install [
 	^ self instance install
 ]

--- a/source/Canopy-Metrics/ExternalSemaphoreTable.extension.st
+++ b/source/Canopy-Metrics/ExternalSemaphoreTable.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : 'ExternalSemaphoreTable' }
 
 { #category : '*Canopy-Metrics' }
+ExternalSemaphoreTable class >> canopyRegister [
+	^ (Canopy /+ #image) merge: (CanopyMappingBuilder new object: self; map: CanopyBranchNode new; build)
+]
+
+{ #category : '*Canopy-Metrics' }
 ExternalSemaphoreTable class >> externalObjectTableSizeCanopy [
 	<canopyValue: #externalObjectTableSize type: #metric arguments: #('The total size of the external object table, including free slots' gauge)>
 	^ self externalObjects size

--- a/source/Canopy-Metrics/File.extension.st
+++ b/source/Canopy-Metrics/File.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : 'File' }
 
 { #category : '*Canopy-Metrics' }
+File class >> canopyRegister [
+	^ (Canopy /+ #image) merge: (CanopyMappingBuilder new object: self; map: CanopyBranchNode new; build)
+]
+
+{ #category : '*Canopy-Metrics' }
 File class >> fileRegistrySizeCanopy [
 	<canopyValue: #fileRegistrySize type: #metric arguments: #('The number of files registered' gauge)>
 	^ self registry size

--- a/source/Canopy-Metrics/Process.extension.st
+++ b/source/Canopy-Metrics/Process.extension.st
@@ -7,6 +7,11 @@ Process class >> activeProcessListCanopy [
 ]
 
 { #category : '*Canopy-Metrics' }
+Process class >> canopyRegister [
+	^ (Canopy /+ #image) merge: (CanopyMappingBuilder new object: self; map: CanopyBranchNode new; build)
+]
+
+{ #category : '*Canopy-Metrics' }
 Process class >> terminatedProcessListCanopy [
 	<canopyValue: #processesTerminated type: #metric arguments: #('The number of terminated processes' gauge)>
 	^ (self allSubInstances select: #isTerminated) size

--- a/source/Canopy-Metrics/SmalltalkImage.extension.st
+++ b/source/Canopy-Metrics/SmalltalkImage.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'SmalltalkImage' }
+
+{ #category : '*Canopy-Metrics' }
+SmalltalkImage class >> canopyRegister [
+	^ (Canopy /+ #image) merge: (CanopyMappingBuilder new object: Smalltalk; map: CanopyBranchNode new; build)
+]

--- a/source/Canopy-Metrics/VirtualMachine.extension.st
+++ b/source/Canopy-Metrics/VirtualMachine.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : 'VirtualMachine' }
 
 { #category : '*Canopy-Metrics' }
+VirtualMachine class >> canopyRegister [
+	^ Canopy registerDomainNamed: #virtualMachine with: (CanopyMappingBuilder new object: Smalltalk vm; map: CanopyBranchNode new; build)
+]
+
+{ #category : '*Canopy-Metrics' }
 VirtualMachine >> edenSpaceSizeCanopy [
 	<canopyValue: #edenSpaceSize type: #metric arguments: #('The size of eden (new space) in bytes' gauge)>
 	^ self edenSpaceSize


### PR DESCRIPTION
…nch for instances

Addresses the "Registrierungsmechanismus" backlog item's two open cases, discussed and scoped down with Norbert (a full automatic PragmaCollector- based scan was explicitly rejected - no real use case for discovering self-registering classes, and the set of singleton/class contributors will always be small and known):

Singletons/classes: each contributing class now owns a simple canopyRegister class method (VirtualMachine, Process, File, ExternalSemaphoreTable, SmalltalkImage, CanopyZincCounter) instead of the knowledge living centrally in Canopy class>>systemMetrics/zincMetrics (both removed). registerImageMetrics/registerVirtualMachineMetrics/registerZincMetrics now just delegate to the relevant class(es)' canopyRegister. New classes can register themselves without ever touching Canopy class.

Arbitrary composed instances: no new mechanism needed - the existing <canopyBranch> pragma (previously only demonstrated via Dictionary>>canopyBranch:) already lets any composed instance wire in its own sub-components via aBuilder at:addMapping:, and canopyMapping already builds the full nested tree from that. Added a demonstration (CanopyComposedAppExample/CanopyComposedSubComponent + testComposedInstanceRegistersAsDomainViaCanopyBranch) proving a composed instance registers correctly as a Canopy domain via registerDomainNamed:with:, fullKey resolving correctly two levels deep.