### PR TITLE
Add CanopyJsonVisitor for generic tree browsing (JSON export)

### DIFF
--- a/source/Canopy-Core-Tests/CanopyJsonVisitorTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyJsonVisitorTest.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : 'CanopyJsonVisitorTest',
+	#superclass : 'TestCase',
+	#category : 'Canopy-Core-Tests',
+	#package : 'Canopy-Core-Tests'
+}
+
+{ #category : 'tests' }
+CanopyJsonVisitorTest >> testFormatBranchNodeProducesNestedJsonObject [
+	| root |
+	root := CanopyBranchNode new.
+	root at: #config put: (CanopyCell new value: 'hello').
+	self assert: (CanopyJsonVisitor new format: root) equals: '{"config":"hello"}'
+]
+
+{ #category : 'tests' }
+CanopyJsonVisitorTest >> testFormatCellReturnsRawJsonValue [
+	self assert: (CanopyJsonVisitor new format: (CanopyCell new value: 'hello')) equals: '"hello"'
+]
+
+{ #category : 'tests' }
+CanopyJsonVisitorTest >> testFormatDictionaryAccessorProducesNestedJsonObjectFromLiveDictionary [
+	| built root |
+	built := CanopyMappingBuilder new object: (CanopyDictionaryTestObject new settings: (Dictionary new at: #a put: 1; yourself); yourself); map: CanopyBranchNode new; build.
+	root := CanopyBranchNode new.
+	root at: #settings put: (built at: #settings).
+	self assert: (CanopyJsonVisitor new format: root) equals: '{"settings":{"a":1}}'
+]
+
+{ #category : 'tests' }
+CanopyJsonVisitorTest >> testFormatMetricAccessorUsesReadSelectorValue [
+	| built root |
+	built := CanopyMappingBuilder new object: (CanopyTestObject new one: 42; yourself); map: CanopyBranchNode new; build.
+	root := CanopyBranchNode new.
+	root at: #one put: (built at: #one).
+	self assert: (CanopyJsonVisitor new format: root) equals: '{"one":42}'
+]
+
+{ #category : 'tests' }
+CanopyJsonVisitorTest >> testFormatWriteOnlyAccessorProducesJsonNullInsteadOfCrashing [
+	"Mirrors CanopyAccessorTest>>testAcceptCanopySkipsWriteOnlyAccessorsInsteadOfCrashing -
+	but unlike the Prometheus visitor (which omits the key entirely), JSON keeps the key
+	with an explicit null so a browse client still sees the leaf exists, just unreadable."
+	| root writeOnly |
+	root := CanopyBranchNode new.
+	writeOnly := CanopyAccessor new object: CanopyTestObject new; writeSelector: #one; yourself.
+	root at: #writeOnlyThing put: writeOnly.
+	self assert: (CanopyJsonVisitor new format: root) equals: '{"writeOnlyThing":null}'
+]

--- a/source/Canopy-Core/CanopyAccessor.class.st
+++ b/source/Canopy-Core/CanopyAccessor.class.st
@@ -27,7 +27,7 @@ CanopyAccessor class >> type [
 CanopyAccessor >> acceptCanopy: aVisitor [
 	"Write-only accessors (no readSelector) contribute nothing to export/formatting -
 	they are not metrics, silently skipped rather than crashing on nil name/description."
-	readSelector ifNotNil: [ aVisitor visitMetric: self ]
+	^ readSelector ifNotNil: [ aVisitor visitMetric: self ]
 ]
 
 { #category : 'accessing' }

--- a/source/Canopy-Core/CanopyBranchNode.class.st
+++ b/source/Canopy-Core/CanopyBranchNode.class.st
@@ -29,8 +29,8 @@ CanopyBranchNode >> @ aSymbol [
 ]
 
 { #category : 'visiting' }
-CanopyBranchNode >> acceptCanopy: aVisitor [ 
-	aVisitor visitBranchNode: self 
+CanopyBranchNode >> acceptCanopy: aVisitor [
+	^ aVisitor visitBranchNode: self
 ]
 
 { #category : 'target resize' }

--- a/source/Canopy-Core/CanopyCell.class.st
+++ b/source/Canopy-Core/CanopyCell.class.st
@@ -10,8 +10,13 @@ Class {
 }
 
 { #category : 'accessing' }
-CanopyCell class >> type [ 
+CanopyCell class >> type [
 	^ #value
+]
+
+{ #category : 'visiting' }
+CanopyCell >> acceptCanopy: aVisitor [
+	^ aVisitor visitCell: self
 ]
 
 { #category : 'initialization' }

--- a/source/Canopy-Core/CanopyDictionaryAccessor.class.st
+++ b/source/Canopy-Core/CanopyDictionaryAccessor.class.st
@@ -20,8 +20,13 @@ CanopyDictionaryAccessor class >> type [
 	^ #dictionary 
 ]
 
+{ #category : 'visiting' }
+CanopyDictionaryAccessor >> acceptCanopy: aVisitor [
+	^ aVisitor visitDictionaryAccessor: self
+]
+
 { #category : 'target resize' }
-CanopyDictionaryAccessor >> apply: aCanopyBranchNode [ 
+CanopyDictionaryAccessor >> apply: aCanopyBranchNode [
 
 	aCanopyBranchNode keysAndValuesDo: [ :key :value |
 		dictionary at: key put: value value ]

--- a/source/Canopy-Core/CanopyJsonVisitor.class.st
+++ b/source/Canopy-Core/CanopyJsonVisitor.class.st
@@ -1,0 +1,40 @@
+Class {
+	#name : 'CanopyJsonVisitor',
+	#superclass : 'CanopyVisitor',
+	#category : 'Canopy-Core',
+	#package : 'Canopy-Core'
+}
+
+{ #category : 'formatting' }
+CanopyJsonVisitor >> format: aNode [
+	^ NeoJSONWriter toString: (self visit: aNode)
+]
+
+{ #category : 'visiting' }
+CanopyJsonVisitor >> visit: anObject [
+	^ anObject acceptCanopy: self
+]
+
+{ #category : 'visiting' }
+CanopyJsonVisitor >> visitBranchNode: aCanopyBranchNode [
+	| result |
+	result := Dictionary new.
+	aCanopyBranchNode nodes keysAndValuesDo: [ :key :childNode |
+		result at: key put: (self visit: childNode) ].
+	^ result
+]
+
+{ #category : 'visiting' }
+CanopyJsonVisitor >> visitCell: aCanopyCell [
+	^ aCanopyCell value
+]
+
+{ #category : 'visiting' }
+CanopyJsonVisitor >> visitDictionaryAccessor: aCanopyDictionaryAccessor [
+	^ aCanopyDictionaryAccessor value
+]
+
+{ #category : 'visiting' }
+CanopyJsonVisitor >> visitMetric: aCanopyAccessor [
+	^ aCanopyAccessor value
+]

--- a/source/Canopy-Core/CanopyJsonVisitor.class.st
+++ b/source/Canopy-Core/CanopyJsonVisitor.class.st
@@ -7,7 +7,7 @@ Class {
 
 { #category : 'formatting' }
 CanopyJsonVisitor >> format: aNode [
-	^ NeoJSONWriter toString: (self visit: aNode)
+	^ STON toJsonString: (self visit: aNode)
 ]
 
 { #category : 'visiting' }


### PR DESCRIPTION
Second of two planned HTTP endpoints (Canopy roadmap, HTTP Browse & Edit Handler): a CanopyVisitor that serialises any node (branch or leaf) to JSON, needed for the upcoming GET browse handler.

Required a small prerequisite fix: acceptCanopy: never returned the visitor's result (missing ^), which the stream-based CanopyPrometheusVisitor never needed but a value-building visitor does. Also added the previously-missing acceptCanopy: for CanopyCell/CanopyDictionaryAccessor - both leaf types could not be visited at all before (doesNotUnderstand), since only CanopyAccessor/ CanopyBranchNode implemented it. Both changes are behaviour-preserving for existing visitors (Canopy-Metrics-Tests: 12/12 still green).

Write-only accessors (no readSelector) serialise as JSON null rather than being omitted, unlike the Prometheus visitor - a browse client should still see the leaf exists.

CanopyMetricGroup/CanopyMetricMap (Canopy-Metrics) are not yet covered by this visitor - out of scope here to avoid a Core->Metrics dependency; can be added later as a Canopy-Metrics extension method if the browse endpoint ever needs to expose metrics domains too.