### PR TITLE
Add CanopyMetricsHandler for Prometheus HTTP export

### DIFF
--- a/source/Canopy-Metrics-Tests/CanopyMetricsHandlerTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyMetricsHandlerTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'CanopyMetricsHandlerTest',
+	#superclass : 'TestCase',
+	#category : 'Canopy-Metrics-Tests',
+	#package : 'Canopy-Metrics-Tests'
+}
+
+{ #category : 'tests' }
+CanopyMetricsHandlerTest >> testHandleRequestReturnsPrometheusFormattedCanopyTree [
+	"CanopyMetricsHandler mirrors pharo-metrics' MetricsHandler as a plain Zinc handleRequest: -
+	no HOP dependency, mountable anywhere (Canopy roadmap, HTTP-Scrape-Endpoint)."
+	| mapping response |
+	mapping := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	[ Canopy instance registerDomainNamed: #testMetrics with: mapping.
+	response := CanopyMetricsHandler new handleRequest: nil.
+	self assert: response isSuccess.
+	self assert: response contentType equals: ZnMimeType textPlain setCharSetUTF8.
+	self assert: (response entity contents includesSubstring: 'testMetrics_memorySize')
+	] ensure: [ Canopy reset ]
+]

--- a/source/Canopy-Metrics/CanopyMetricsHandler.class.st
+++ b/source/Canopy-Metrics/CanopyMetricsHandler.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : 'CanopyMetricsHandler',
+	#superclass : 'Object',
+	#category : 'Canopy-Metrics',
+	#package : 'Canopy-Metrics'
+}
+
+{ #category : 'accessing' }
+CanopyMetricsHandler >> formatter [
+	^ CanopyPrometheusVisitor new
+]
+
+{ #category : 'public' }
+CanopyMetricsHandler >> handleRequest: request [
+	^ ZnResponse ok: (ZnEntity
+		with: (self formatter format: Canopy instance)
+		type: ZnMimeType textPlain setCharSetUTF8)
+]


### PR DESCRIPTION
Plain Zinc handleRequest: handler mirroring pharo-metrics' MetricsHandler - no HOP dependency, mountable anywhere. First of two planned HTTP endpoints (Canopy roadmap, HTTP-Scrape-Endpoint fuer Prometheus-Export); the second (domain browse/write via GET/PUT) follows in a separate PR.