### PR TITLE
Make CanopyMetricsHandler configurable with domain selection + prefix

### DIFF
--- a/source/Canopy-Metrics-Tests/CanopyMetricsHandlerTest.class.st
+++ b/source/Canopy-Metrics-Tests/CanopyMetricsHandlerTest.class.st
@@ -18,3 +18,50 @@ CanopyMetricsHandlerTest >> testHandleRequestReturnsPrometheusFormattedCanopyTre
 	self assert: (response entity contents includesSubstring: 'testMetrics_memorySize')
 	] ensure: [ Canopy reset ]
 ]
+
+{ #category : 'tests' }
+CanopyMetricsHandlerTest >> testHandleRequestWithoutConfigExportsAllRegisteredDomains [
+	"Default (no addDomain: configured): the whole Canopy tree is exported, every domain,
+	unprefixed - unchanged from the original handler behavior (Norbert, 2026-07-27)."
+	| alpha beta response body |
+	alpha := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	beta := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	[ Canopy instance registerDomainNamed: #alpha with: alpha.
+	Canopy instance registerDomainNamed: #beta with: beta.
+	response := CanopyMetricsHandler new handleRequest: nil.
+	body := response entity contents.
+	self assert: (body includesSubstring: 'alpha_memorySize').
+	self assert: (body includesSubstring: 'beta_memorySize')
+	] ensure: [ Canopy reset ]
+]
+
+{ #category : 'tests' }
+CanopyMetricsHandlerTest >> testHandleRequestWithConfiguredPrefixPrependsPrefix [
+	"A configured domain can carry an export prefix (Option B, Canopy roadmap) - the metric
+	name is prefixed, mirroring the old pharo_ namespace for system domains."
+	| mapping handler response |
+	mapping := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	[ Canopy instance registerDomainNamed: #virtualMachine with: mapping.
+	handler := CanopyMetricsHandler new.
+	handler addDomain: #virtualMachine prefix: 'pharo'.
+	response := handler handleRequest: nil.
+	self assert: (response entity contents includesSubstring: 'pharo_virtualMachine_memorySize')
+	] ensure: [ Canopy reset ]
+]
+
+{ #category : 'tests' }
+CanopyMetricsHandlerTest >> testHandleRequestWithConfigOnlyExportsConfiguredDomains [
+	"Configuring domains selects them: only the added domain is exported, siblings are skipped
+	(not every domain has to be exported - Norbert, 2026-07-27)."
+	| alpha beta handler body |
+	alpha := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	beta := CanopyMappingBuilder new object: CanopyMetricsTestObject new; map: CanopyBranchNode new; build.
+	[ Canopy instance registerDomainNamed: #alpha with: alpha.
+	Canopy instance registerDomainNamed: #beta with: beta.
+	handler := CanopyMetricsHandler new.
+	handler addDomain: #alpha.
+	body := (handler handleRequest: nil) entity contents.
+	self assert: (body includesSubstring: 'alpha_memorySize').
+	self deny: (body includesSubstring: 'beta')
+	] ensure: [ Canopy reset ]
+]

--- a/source/Canopy-Metrics/CanopyMetricsHandler.class.st
+++ b/source/Canopy-Metrics/CanopyMetricsHandler.class.st
@@ -1,9 +1,26 @@
 Class {
 	#name : 'CanopyMetricsHandler',
 	#superclass : 'Object',
+	#instVars : [
+		'exports'
+	],
 	#category : 'Canopy-Metrics',
 	#package : 'Canopy-Metrics'
 }
+
+{ #category : 'configuring' }
+CanopyMetricsHandler >> addDomain: aSymbol [
+	"Export the domain aSymbol (resolved fresh per request via Canopy /) without a prefix.
+	Configuring any domain switches this handler out of the default all-domains mode."
+	exports add: aSymbol -> nil
+]
+
+{ #category : 'configuring' }
+CanopyMetricsHandler >> addDomain: aSymbol prefix: aString [
+	"Export the domain aSymbol, prefixing every metric name with aString (e.g. prefix: 'pharo'
+	yields pharo_virtualMachine_memorySize). See CanopyPrometheusVisitor>>addDomain:prefix:."
+	exports add: aSymbol -> aString
+]
 
 { #category : 'accessing' }
 CanopyMetricsHandler >> formatter [
@@ -13,6 +30,27 @@ CanopyMetricsHandler >> formatter [
 { #category : 'public' }
 CanopyMetricsHandler >> handleRequest: request [
 	^ ZnResponse ok: (ZnEntity
-		with: (self formatter format: Canopy instance)
+		with: self prometheusText
 		type: ZnMimeType textPlain setCharSetUTF8)
+]
+
+{ #category : 'initialization' }
+CanopyMetricsHandler >> initialize [
+	super initialize.
+	exports := OrderedCollection new.
+]
+
+{ #category : 'public' }
+CanopyMetricsHandler >> prometheusText [
+	"With no configured domains, export the whole Canopy tree (all domains, unprefixed) - the
+	default. With domains configured, export only those, each with its optional prefix, resolving
+	each domain fresh so metric values stay live and re-registration is picked up."
+	| visitor |
+	exports isEmpty ifTrue: [ ^ self formatter format: Canopy instance ].
+	visitor := self formatter.
+	exports do: [ :assoc |
+		assoc value
+			ifNil: [ visitor addDomain: (Canopy / assoc key) ]
+			ifNotNil: [ visitor addDomain: (Canopy / assoc key) prefix: assoc value ] ].
+	^ visitor export
 ]


### PR DESCRIPTION
Builds on the visitor's addDomain:/addDomain:prefix: API. The handler now lets a caller choose which domains the scrape endpoint exports and optionally prefix a domain's metric names (e.g. #virtualMachine prefix: 'pharo').

- addDomain: / addDomain:prefix: configure the selection (domain names as symbols).
- prometheusText resolves each configured domain fresh per request (values stay live), then exports via the visitor.
- Default is unchanged: with no domains configured, the whole Canopy tree is exported (all domains, unprefixed) exactly as before.

Canopy-Metrics-Tests 20/20, Canopy-Core-Tests 73/73 green.