### PR TITLE
Render branches as an HTML list of child links in CanopyBrowseHtmlHan…

### DIFF
--- a/source/Canopy-Core-Tests/CanopyBrowseHtmlHandlerTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyBrowseHtmlHandlerTest.class.st
@@ -26,12 +26,34 @@ CanopyBrowseHtmlHandlerTest >> requestFor: method url: aUrl accept: anAcceptStri
 ]
 
 { #category : 'tests' }
-CanopyBrowseHtmlHandlerTest >> testHandleRequestDelegatesBranchToJsonEvenWhenAcceptIsHtml [
-	"Browsable HTML links for branches need trailing-slash canonicalisation for correct
-	relative resolution - deliberately out of scope for this first version, so branches
-	always get JSON regardless of Accept."
+CanopyBrowseHtmlHandlerTest >> testHandleRequestRendersHtmlListForBranchWhenAcceptIsHtml [
+	"A branch now renders as an HTML page: its path as title plus one link per child node
+	(absolute hrefs). Order is dictionary-defined, so assert per child, not the whole string."
+	| body response |
 	[ self registerBrowseTestDomain.
-	self assert: (CanopyBrowseHtmlHandler new handleRequest: (self requestFor: #GET url: 'http://localhost/browseTest/sub' accept: 'text/html' body: nil)) contentType equals: ZnMimeType applicationJson
+	response := CanopyBrowseHtmlHandler new handleRequest: (self requestFor: #GET url: 'http://localhost/browseTest' accept: 'text/html' body: nil).
+	self assert: response contentType equals: ZnMimeType textHtml.
+	body := response entity contents.
+	self assert: (body includesSubstring: '<h1>/browseTest</h1>').
+	self assert: (body includesSubstring: '<li><a href="/browseTest/a">a</a></li>').
+	self assert: (body includesSubstring: '<li><a href="/browseTest/sub">sub</a></li>')
+	] ensure: [ Canopy reset ]
+]
+
+{ #category : 'tests' }
+CanopyBrowseHtmlHandlerTest >> testHandleRequestRendersNestedBranchChildLinksAbsolutely [
+	"Child links of a nested branch keep the full path from root, so following them lands on
+	the child, not a sibling - the trailing-slash resolution issue that had this deferred."
+	[ self registerBrowseTestDomain.
+	self assert: ((CanopyBrowseHtmlHandler new handleRequest: (self requestFor: #GET url: 'http://localhost/browseTest/sub' accept: 'text/html' body: nil)) entity contents includesSubstring: '<li><a href="/browseTest/sub/b">b</a></li>')
+	] ensure: [ Canopy reset ]
+]
+
+{ #category : 'tests' }
+CanopyBrowseHtmlHandlerTest >> testHandleRequestDelegatesBranchToJsonWhenAcceptIsNotHtml [
+	"Without text/html in Accept, a branch still gets plain JSON (the decorator only adds HTML)."
+	[ self registerBrowseTestDomain.
+	self assert: (CanopyBrowseHtmlHandler new handleRequest: (self requestFor: #GET url: 'http://localhost/browseTest/sub' accept: 'application/json' body: nil)) contentType equals: ZnMimeType applicationJson
 	] ensure: [ Canopy reset ]
 ]
 

--- a/source/Canopy-Core/CanopyBrowseHtmlHandler.class.st
+++ b/source/Canopy-Core/CanopyBrowseHtmlHandler.class.st
@@ -16,23 +16,54 @@ CanopyBrowseHtmlHandler >> handleRequest: request [
 
 { #category : 'private' }
 CanopyBrowseHtmlHandler >> handleHtmlRequest: request [
-	"HTML is only rendered for leaf values (the concrete ask: show a value, edit it via PUT).
-	Branches still get JSON regardless of Accept - browsable HTML links for branches need
-	trailing-slash canonicalization for correct relative resolution, deliberately out of scope
-	for this first version."
+	"A branch renders as its title plus a list of links to its children (GET); a leaf renders
+	its value in an editable field that PUTs the new value. PUT on a branch is not a leaf edit,
+	so it delegates to the JSON handler (apply: semantics) unchanged."
 	| method node |
 	method := request method asUppercase.
 	(method = 'GET' or: [ method = 'PUT' ]) ifFalse: [ ^ ZnResponse methodNotAllowed: request ].
 	node := [ self restHandler resolveNode: request uri pathSegments ]
 		on: NotFound
 		do: [ :e | ^ ZnResponse notFound: request uri ].
-	(node isKindOf: CanopyBranchNode) ifTrue: [ ^ self restHandler handleRequest: request ].
+	(node isKindOf: CanopyBranchNode) ifTrue: [
+		method = 'GET' ifFalse: [ ^ self restHandler handleRequest: request ].
+		^ ZnResponse ok: (ZnEntity with: (self branchPageFor: node path: request uri path) type: ZnMimeType textHtml) ].
 	method = 'PUT' ifTrue: [
 		| writeResponse |
 		writeResponse := self restHandler handlePut: request.
 		writeResponse isSuccess ifFalse: [ ^ writeResponse ].
 		node := self restHandler resolveNode: request uri pathSegments ].
 	^ ZnResponse ok: (ZnEntity with: (self pageFor: node path: request uri path) type: ZnMimeType textHtml)
+]
+
+{ #category : 'private' }
+CanopyBrowseHtmlHandler >> branchPageFor: node path: pathString [
+	"Title (the current path) plus one link per child node. Child links are absolute
+	(rooted at /) so they resolve correctly regardless of a trailing slash on the request URI."
+	^ String streamContents: [ :s |
+		s nextPutAll: '<!DOCTYPE html><html><body>'.
+		s nextPutAll: '<h1>/'; nextPutAll: (self htmlEscape: pathString); nextPutAll: '</h1>'.
+		s nextPutAll: '<ul>'.
+		node keysAndValuesDo: [ :key :child |
+			s nextPutAll: '<li><a href="';
+				nextPutAll: (self htmlEscape: (self childHref: pathString key: key));
+				nextPutAll: '">';
+				nextPutAll: (self htmlEscape: key asString);
+				nextPutAll: '</a></li>' ].
+		s nextPutAll: '</ul></body></html>' ]
+]
+
+{ #category : 'private' }
+CanopyBrowseHtmlHandler >> childHref: pathString key: key [
+	"Absolute path to a child: /<currentPath>/<key>, tolerant of a leading or trailing slash
+	on pathString and of an empty pathString (the root)."
+	| trimmed |
+	trimmed := pathString.
+	(trimmed beginsWith: '/') ifTrue: [ trimmed := trimmed allButFirst ].
+	(trimmed endsWith: '/') ifTrue: [ trimmed := trimmed allButLast ].
+	^ trimmed isEmpty
+		ifTrue: [ '/' , key asString ]
+		ifFalse: [ '/' , trimmed , '/' , key asString ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
…dler

A branch now renders as an HTML page (title + one link per child node) when Accept: text/html, instead of falling back to JSON. Leaf rendering (value + edit form) is unchanged; PUT on a branch still delegates to the JSON handler.

Child links are absolute (/<path>/<key>), which sidesteps the trailing-slash relative-resolution issue that had this deferred - no canonicalization needed.

- handleHtmlRequest: branch + GET -> branchPageFor:path:.
- branchPageFor:path: / childHref:key: added.
- The old "branch stays JSON even with html Accept" test is replaced by tests for the list rendering, absolute nested child links, and branch-stays-JSON when Accept is not html.

Note: tests were written but NOT executed in this session (Pharo MCP was unavailable here) - verification still pending.