### PR TITLE
Render a branch as a table with inline leaf editing

### DIFF
--- a/source/Canopy-Core-Tests/CanopyBrowseHtmlHandlerTest.class.st
+++ b/source/Canopy-Core-Tests/CanopyBrowseHtmlHandlerTest.class.st
@@ -26,26 +26,36 @@ CanopyBrowseHtmlHandlerTest >> requestFor: method url: aUrl accept: anAcceptStri
 ]
 
 { #category : 'tests' }
-CanopyBrowseHtmlHandlerTest >> testHandleRequestRendersHtmlListForBranchWhenAcceptIsHtml [
-	"A branch now renders as an HTML page: its path as title plus one link per child node
-	(absolute hrefs). Order is dictionary-defined, so assert per child, not the whole string."
+CanopyBrowseHtmlHandlerTest >> testHandleRequestRendersBranchAsTableWithLeafInputsAndBranchLinks [
+	"A branch renders as a table: leaf children get their value in an inline input next to the
+	name (Save PUTs to the child URL); branch children are links to drill in. Order is
+	dictionary-defined, so assert per child, not the whole string."
 	| body response |
 	[ self registerBrowseTestDomain.
 	response := CanopyBrowseHtmlHandler new handleRequest: (self requestFor: #GET url: 'http://localhost/browseTest' accept: 'text/html' body: nil).
 	self assert: response contentType equals: ZnMimeType textHtml.
 	body := response entity contents.
 	self assert: (body includesSubstring: '<h1>/browseTest</h1>').
-	self assert: (body includesSubstring: '<li><a href="/browseTest/a">a</a></li>').
-	self assert: (body includesSubstring: '<li><a href="/browseTest/sub">sub</a></li>')
+	self assert: (body includesSubstring: '<table>').
+	"leaf child a -> name cell + editable input + Save button targeting its URL"
+	self assert: (body includesSubstring: '<td>a</td>').
+	self assert: (body includesSubstring: 'value="&quot;x&quot;"').
+	self assert: (body includesSubstring: 'data-href="/browseTest/a"').
+	"branch child sub -> link to drill in"
+	self assert: (body includesSubstring: '<a href="/browseTest/sub">sub</a>')
 	] ensure: [ Canopy reset ]
 ]
 
 { #category : 'tests' }
-CanopyBrowseHtmlHandlerTest >> testHandleRequestRendersNestedBranchChildLinksAbsolutely [
-	"Child links of a nested branch keep the full path from root, so following them lands on
-	the child, not a sibling - the trailing-slash resolution issue that had this deferred."
+CanopyBrowseHtmlHandlerTest >> testHandleRequestRendersLeafChildAsInlineInputWithAbsoluteHref [
+	"A leaf child inside a (nested) branch table gets its value in an input and a Save button
+	whose data-href is the child's full path from root, so the PUT lands on the child."
+	| body |
 	[ self registerBrowseTestDomain.
-	self assert: ((CanopyBrowseHtmlHandler new handleRequest: (self requestFor: #GET url: 'http://localhost/browseTest/sub' accept: 'text/html' body: nil)) entity contents includesSubstring: '<li><a href="/browseTest/sub/b">b</a></li>')
+	body := (CanopyBrowseHtmlHandler new handleRequest: (self requestFor: #GET url: 'http://localhost/browseTest/sub' accept: 'text/html' body: nil)) entity contents.
+	self assert: (body includesSubstring: '<td>b</td>').
+	self assert: (body includesSubstring: 'value="99"').
+	self assert: (body includesSubstring: 'data-href="/browseTest/sub/b"')
 	] ensure: [ Canopy reset ]
 ]
 

--- a/source/Canopy-Core/CanopyBrowseHtmlHandler.class.st
+++ b/source/Canopy-Core/CanopyBrowseHtmlHandler.class.st
@@ -38,19 +38,30 @@ CanopyBrowseHtmlHandler >> handleHtmlRequest: request [
 
 { #category : 'private' }
 CanopyBrowseHtmlHandler >> branchPageFor: node path: pathString [
-	"Title (the current path) plus one link per child node. Child links are absolute
-	(rooted at /) so they resolve correctly regardless of a trailing slash on the request URI."
+	"Title (the current path) plus a table with one row per child. A branch child is a link to
+	drill in; a leaf child gets its value in an editable input next to its name, with a Save
+	button that PUTs to the child's absolute URL. Child URLs are absolute (rooted at /) so they
+	resolve regardless of a trailing slash on the request URI."
 	^ String streamContents: [ :s |
 		s nextPutAll: '<!DOCTYPE html><html><body>'.
 		s nextPutAll: '<h1>/'; nextPutAll: (self htmlEscape: pathString); nextPutAll: '</h1>'.
-		s nextPutAll: '<ul>'.
+		s nextPutAll: '<table>'.
 		node keysAndValuesDo: [ :key :child |
-			s nextPutAll: '<li><a href="';
-				nextPutAll: (self htmlEscape: (self childHref: pathString key: key));
-				nextPutAll: '">';
-				nextPutAll: (self htmlEscape: key asString);
-				nextPutAll: '</a></li>' ].
-		s nextPutAll: '</ul></body></html>' ]
+			| href |
+			href := self childHref: pathString key: key.
+			s nextPutAll: '<tr>'.
+			(child isKindOf: CanopyBranchNode)
+				ifTrue: [
+					s nextPutAll: '<td><a href="'; nextPutAll: (self htmlEscape: href); nextPutAll: '">';
+						nextPutAll: (self htmlEscape: key asString); nextPutAll: '</a></td><td></td>' ]
+				ifFalse: [
+					s nextPutAll: '<td>'; nextPutAll: (self htmlEscape: key asString); nextPutAll: '</td>'.
+					s nextPutAll: '<td><input value="'; nextPutAll: (self htmlEscape: (CanopyJsonVisitor new format: child));
+						nextPutAll: '"><button data-href="'; nextPutAll: (self htmlEscape: href); nextPutAll: '">Save</button></td>' ].
+			s nextPutAll: '</tr>' ].
+		s nextPutAll: '</table>'.
+		s nextPutAll: '<script>document.querySelectorAll("button[data-href]").forEach(function(b){b.addEventListener("click",function(){fetch(b.getAttribute("data-href"),{method:"PUT",body:b.previousElementSibling.value}).then(function(){location.reload();});});});</script>'.
+		s nextPutAll: '</body></html>' ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
A branch now renders as a table, one row per child: a branch child is a link to drill in; a leaf child shows its value in an editable input right next to the name, with a Save button that PUTs the new value to the child's absolute URL (one delegated script wires all Save buttons). This replaces the plain <ul> of links from the previous version, so leaf values are editable inline without navigating to a separate per-leaf page. The single-leaf page (direct leaf URL) is unchanged.

Branch-rendering tests updated for the table (leaf inline input + data-href, branch link); branch-stays-JSON-without-html-Accept and the leaf-page tests are unchanged.

Note: tests were written but NOT executed in this session (Pharo MCP was unavailable here) - verification still pending.